### PR TITLE
Changed some requires to link to index.js instead of the lib name.

### DIFF
--- a/lib/Proj.js
+++ b/lib/Proj.js
@@ -1,9 +1,9 @@
 var extend = require('./extend');
 var common = require('./common');
 var defs = require('./defs');
-var constants = require('./constants');
+var constants = require('./constants/index');
 var datum = require('./datum');
-var projections = require('./projections');
+var projections = require('./projections/index');
 var wkt = require('./wkt');
 var projStr = require('./projString');
 

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,1 +1,0 @@
-module.exports = require('./constants/index.js');

--- a/lib/projString.js
+++ b/lib/projString.js
@@ -1,5 +1,5 @@
 var common = require('./common');
-var constants = require('./constants');
+var constants = require('./constants/index');
 module.exports = function(defData) {
   var self = {};
 

--- a/lib/projections.js
+++ b/lib/projections.js
@@ -1,1 +1,0 @@
-module.exports = require('./projections/index.js');


### PR DESCRIPTION
I also like the browserify version a lot better because now I can simply copy this into a CouchDB design doc and use it. The only problem is that erica cannot push for instance 'constants.js' AND the directory 'constants' (they resolve to the same property 'constants'). So if we require ./constants/index instead of ./constants this will work just fine.

Cheerio
Oscar
