### PR TITLE
Allow to push the tag

### DIFF
--- a/publish.sh
+++ b/publish.sh
@@ -10,7 +10,7 @@ git add bower.json
 git add component.json
 git commit -m build
 git tag $1
-git push git@github.com:proj4js/proj4js.git $1
+git push --tags git@github.com:proj4js/proj4js.git $1
 npm publish
 jam publish
 git checkout master


### PR DESCRIPTION
We don't get a tag pushed with the current `publish.sh` script. This pull request should fix it.
