### PR TITLE
eqc projection typo in lat_ts

### DIFF
--- a/lib/projections/eqc.js
+++ b/lib/projections/eqc.js
@@ -5,7 +5,7 @@ exports.init = function() {
   this.y0 = this.y0 || 0;
   this.lat0 = this.lat0 || 0;
   this.long0 = this.long0 || 0;
-  this.lat_ts = this.lat_t || 0;
+  this.lat_ts = this.lat_ts || 0;
   this.title = this.title || "Equidistant Cylindrical (Plate Carre)";
 
   this.rc = Math.cos(this.lat_ts);


### PR DESCRIPTION
The eqc projection is missing its latitude of true scale due to a typo in the init function, which is causing it to produce incorrect results.
