### PR TITLE
(#89) - remove point class

### DIFF
--- a/lib/Point.js
+++ b/lib/Point.js
@@ -23,30 +23,7 @@ function Point(x, y, z) {
     this.y = y;
     this.z = z || 0.0;
   }
-  this.clone = function() {
-    return new Point(this.x, this.y, this.z);
-  };
-  this.toArray = function(){
-    if(this.z){
-      return [this.x,this.y, this.z];
-    }else{
-      return [this.x,this.y];
-    }
-  };
-  this.toString = function() {
-    if(this.z){
-      return "x=" + this.x + ",y=" + this.y + ",z="+this.z;
-    }else{
-      return "x=" + this.x + ",y=" + this.y;
-    }
-  };
-  this.toShortString = function() {
-    if(this.z){
-      return this.x + "," + this.y+ "," + this.z;
-    }else{
-      return this.x + "," + this.y;
-    }
-  };
+  console.warn('proj4.Point will be removed in version 3, use proj4.toPoint');
 }
 
 Point.fromMGRS = function(mgrsStr) {

--- a/lib/common/toPoint.js
+++ b/lib/common/toPoint.js
@@ -1,0 +1,13 @@
+module.exports = function (array){
+  var out = {
+    x: array[0],
+    y: array[1]
+  };
+  if (array.length>2) {
+    out.z = array[2];
+  }
+  if (array.length>3) {
+    out.m = array[3];
+  }
+  return out;
+};

--- a/lib/core.js
+++ b/lib/core.js
@@ -1,4 +1,3 @@
-var point = require('./Point');
 var proj = require('./Proj');
 var transform = require('./transform');
 var wgs84 = proj('WGS84');
@@ -6,7 +5,7 @@ var wgs84 = proj('WGS84');
 function transformer(from, to, coords) {
   var transformedArray;
   if (Array.isArray(coords)) {
-    transformedArray = transform(from, to, point(coords));
+    transformedArray = transform(from, to, coords);
     if (coords.length === 3) {
       return [transformedArray.x, transformedArray.y, transformedArray.z];
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,6 +3,7 @@ proj4.defaultDatum = 'WGS84'; //default datum
 proj4.Proj = require('./Proj');
 proj4.WGS84 = new proj4.Proj('WGS84');
 proj4.Point = require('./Point');
+proj4.toPoint = require("./common/toPoint");
 proj4.defs = require('./defs');
 proj4.transform = require('./transform');
 proj4.mgrs = require('mgrs');

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -5,9 +5,12 @@ var PJD_7PARAM = 2;
 var datum_transform = require('./datum_transform');
 var adjust_axis = require('./adjust_axis');
 var proj = require('./Proj');
+var toPoint = require('./common/toPoint');
 module.exports = function transform(source, dest, point) {
   var wgs84;
-
+  if (Array.isArray(point)) {
+    point = toPoint(point);
+  }
   function checkNotWGS(source, dest) {
     return ((source.datum.datum_type === PJD_3PARAM || source.datum.datum_type === PJD_7PARAM) && dest.datumCode !== "WGS84");
   }

--- a/test/test.js
+++ b/test/test.js
@@ -49,13 +49,13 @@ function startTests(chai, proj4, testPoints) {
           describe('traditional', function() {
             it('should work with forwards', function() {
               var proj = new proj4.Proj(testPoint.code);
-              var xy = proj4.transform(proj4.WGS84, proj, new proj4.Point(testPoint.ll));
+              var xy = proj4.transform(proj4.WGS84, proj, proj4.toPoint(testPoint.ll));
               assert.closeTo(xy.x, testPoint.xy[0], xyEPSLN, 'x is close');
               assert.closeTo(xy.y, testPoint.xy[1], xyEPSLN, 'y is close');
             });
             it('should work with backwards', function() {
               var proj = new proj4.Proj(testPoint.code);
-              var ll = proj4.transform(proj, proj4.WGS84, new proj4.Point(testPoint.xy));
+              var ll = proj4.transform(proj, proj4.WGS84, proj4.toPoint(testPoint.xy));
               assert.closeTo(ll.x, testPoint.ll[0], llEPSLN, 'lng is close');
               assert.closeTo(ll.y, testPoint.ll[1], llEPSLN, 'lat is close');
             });
@@ -76,7 +76,7 @@ function startTests(chai, proj4, testPoints) {
               assert.closeTo(xy.y, testPoint.xy[1], xyEPSLN, 'y is close');
             });
             it('shortcut method should work with a point object', function() {
-              var pt = new proj4.Point(testPoint.ll);
+              var pt = proj4.toPoint(testPoint.ll);
               var xy = proj4(testPoint.code, pt);
               assert.closeTo(xy.x, testPoint.xy[0], xyEPSLN, 'x is close');
               assert.closeTo(xy.y, testPoint.xy[1], xyEPSLN, 'y is close');
@@ -98,7 +98,7 @@ function startTests(chai, proj4, testPoints) {
               assert.closeTo(xy.y, testPoint.xy[1], xyEPSLN, 'y is close');
             });
             it('shortcut method should work with a point object', function() {
-              var pt = new proj4.Point(testPoint.ll);
+              var pt = proj4.toPoint(testPoint.ll);
               var xy = proj4(proj4.WGS84, testPoint.code, pt);
               assert.closeTo(xy.x, testPoint.xy[0], xyEPSLN, 'x is close');
               assert.closeTo(xy.y, testPoint.xy[1], xyEPSLN, 'y is close');
@@ -120,7 +120,7 @@ function startTests(chai, proj4, testPoints) {
               assert.closeTo(ll.y, testPoint.ll[1], llEPSLN, 'y is close');
             });
             it('shortcut method should work with a point object', function() {
-              var pt = new proj4.Point(testPoint.xy);
+              var pt = proj4.toPoint(testPoint.xy);
               var ll = proj4(testPoint.code, proj4.WGS84, pt);
               assert.closeTo(ll.x, testPoint.ll[0], llEPSLN, 'x is close');
               assert.closeTo(ll.y, testPoint.ll[1], llEPSLN, 'y is close');
@@ -150,7 +150,7 @@ function startTests(chai, proj4, testPoints) {
               assert.closeTo(xy[1], testPoint.xy[1], xyEPSLN, 'y is close');
             });
             it('should work 3 element ponit object', function() {
-              var pt = new proj4.Point(testPoint.xy);
+              var pt = proj4.toPoint(testPoint.xy);
               var ll = proj4(new proj4.Proj(testPoint.code), proj4.WGS84, pt);
               assert.closeTo(ll.x, testPoint.ll[0], llEPSLN, 'x is close');
               assert.closeTo(ll.y, testPoint.ll[1], llEPSLN, 'y is close');
@@ -206,88 +206,6 @@ function startTests(chai, proj4, testPoints) {
           assert.equal(point.toMGRS(3), "25XEN041865", "MGRS reference with 3-digit accuracy correct.");
         });
       })
-      describe('points', function() {
-        describe('from params', function() {
-          it('should work with 2 params', function() {
-            var point = proj4.Point(1, 2);
-            assert.equal(point.x, 1);
-            assert.equal(point.y, 2);
-            assert.equal(point.z, 0);
-            assert.equal(point.toShortString(), "1,2");
-            assert.equal(point.toString(), "x=1,y=2");
-            assert.deepEqual(point.toArray(), [1, 2]);
-          });
-          it('should work with 3 params', function() {
-            var point = proj4.Point(1, 2, 3);
-            assert.equal(point.x, 1);
-            assert.equal(point.y, 2);
-            assert.equal(point.z, 3);
-            assert.equal(point.toShortString(), "1,2,3");
-            assert.equal(point.toString(), "x=1,y=2,z=3");
-            assert.deepEqual(point.toArray(), [1, 2, 3]);
-          });
-        });
-        describe('from an obj', function() {
-          it('should work with 2 params', function() {
-            var point = proj4.Point({x:1, y:2});
-            assert.equal(point.x, 1);
-            assert.equal(point.y, 2);
-            assert.equal(point.z, 0);
-            assert.equal(point.toString(), "x=1,y=2");
-            assert.equal(point.toShortString(), "1,2");
-            assert.deepEqual(point.toArray(), [1, 2]);
-          });
-          it('should work with 3 params', function() {
-            var point = proj4.Point({x:1, y:2, z:3});
-            assert.equal(point.x, 1);
-            assert.equal(point.y, 2);
-            assert.equal(point.z, 3);
-            assert.equal(point.toShortString(), "1,2,3");
-            assert.equal(point.toString(), "x=1,y=2,z=3");
-            assert.deepEqual(point.toArray(), [1, 2, 3]);
-          });
-        });
-        describe('from an array', function() {
-          it('should work with 2 params', function() {
-            var point = proj4.Point([1,2]);
-            assert.equal(point.x, 1);
-            assert.equal(point.y, 2);
-            assert.equal(point.z, 0);
-            assert.equal(point.toString(), "x=1,y=2");
-            assert.equal(point.toShortString(), "1,2");
-            assert.deepEqual(point.toArray(), [1, 2]);
-          });
-          it('should work with 3 params', function() {
-            var point = proj4.Point([1,2,3]);
-            assert.equal(point.x, 1);
-            assert.equal(point.y, 2);
-            assert.equal(point.z, 3);
-            assert.equal(point.toShortString(), "1,2,3");
-            assert.equal(point.toString(), "x=1,y=2,z=3");
-            assert.deepEqual(point.toArray(), [1, 2, 3]);
-          });
-        });
-        describe('from a string', function() {
-          it('should work with 2 params', function() {
-            var point = proj4.Point('1,2');
-            assert.equal(point.x, 1);
-            assert.equal(point.y, 2);
-            assert.equal(point.z, 0);
-            assert.equal(point.toString(), "x=1,y=2");
-            assert.equal(point.toShortString(), "1,2");
-            assert.deepEqual(point.toArray(), [1, 2]);
-          });
-          it('should work with 3 params', function() {
-            var point = proj4.Point('1,2,3');
-            assert.equal(point.x, 1);
-            assert.equal(point.y, 2);
-            assert.equal(point.z, 3);
-            assert.equal(point.toString(), "x=1,y=2,z=3");
-            assert.equal(point.toShortString(), "1,2,3");
-            assert.deepEqual(point.toArray(), [1, 2, 3]);
-          });
-        });
-      });
     });
   });
 }


### PR DESCRIPTION
well doesn't actually take out the point class, but guts it, adds a warning and replaces all internal uses of it with a toPoint function which turns an array into an object, with x and y, and if the array has length longer then 2 adds a z and if longer then 3 adds an m because somebody might use it.

in version 3 point and mgrs can be totally removed. 
