### PR TITLE
minor fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 coverage
 projs.js
 .DS_STORE
+dist

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -36,6 +36,7 @@ module.exports = function(grunt) {
     mocha_phantomjs: {
       all: {
         options: {
+          reporter: "dot",
           urls: [ //my ide requries process.env.IP and PORT
             "http://" + (process.env.IP || "127.0.0.1") + ":" + (process.env.PORT || "8080") + "/test/amd.html",
             "http://" + (process.env.IP || "127.0.0.1") + ":" + (process.env.PORT || "8080") + "/test/opt.html"
@@ -80,9 +81,6 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-contrib-jshint');
   grunt.loadNpmTasks('grunt-contrib-connect');
   grunt.loadNpmTasks('grunt-mocha-phantomjs');
-  grunt.registerTask('version', function() {
-    grunt.file.write('./lib/version.js', "module.exports = '" + grunt.file.readJSON('package.json').version + "';");
-  });
   grunt.registerTask('custom',function(){
     grunt.task.run('browserify', 'uglify');
     var projections = this.args;
@@ -106,7 +104,7 @@ module.exports = function(grunt) {
   });
   grunt.registerTask('build',function(){
     var args = this.args.length?this.args[0].split(','):['default'];
-    grunt.task.run('version', 'jshint', 'custom:'+args.join(':'));
+    grunt.task.run('jshint', 'custom:'+args.join(':'));
   });
   grunt.registerTask('default', ['build:all', 'connect','mocha_phantomjs']);
 };

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -6,8 +6,9 @@ Authors:
 - Didier Richard didier.richardATign.fr
 - Stephen Irons stephen.ironsATclear.net.nz
 - Olivier Terral oterralATgmail.com
+- Calvin Metcalf cmetcalfATappgeo.com
 
-Copyright (c) 2012, Mike Adair, Richard Greenwood, Didier Richard, Stephen Irons and Olivier Terral
+Copyright (c) 2014, Mike Adair, Richard Greenwood, Didier Richard, Stephen Irons, Olivier Terral and Calvin Metcalf
 
  Permission is hereby granted, free of charge, to any person obtaining a
  copy of this software and associated documentation files (the "Software"),

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "proj4",
-  "version": "2.0.0",
+  "version": "2.1.1-prerelease",
   "description": "Proj4js is a JavaScript library to transform point coordinates from one coordinate system to another, including datum transformations.",
   "homepage": "https://github.com/proj4js/proj4js",
   "main": "dist/proj4.js",

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,7 @@
 Change log
 ===
+- 2.1.1: tweaks to how we publish it, fixes related to errors with the OSGB36 and Reseau National Belge 1972 datums, we took the first steps towards depreciating the proj4.Point class.
+
 - 2.1.0: targeted builds for projections are now supported, and internally projection creation is more modular.
 
 - 2.0.3: mgrs is broken out into it's own module loaded via npm.

--- a/component.json
+++ b/component.json
@@ -1,6 +1,6 @@
 {
   "name": "proj4",
-  "version": "2.0.0",
+  "version": "2.1.1-prerelease",
   "description": "Proj4js is a JavaScript library to transform point coordinates from one coordinate system to another, including datum transformations.",
   "repo": "proj4js/proj4js",
   "keywords": [

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,6 +6,6 @@ proj4.Point = require('./Point');
 proj4.defs = require('./defs');
 proj4.transform = require('./transform');
 proj4.mgrs = require('mgrs');
-proj4.version = require('./version');
+proj4.version = require('../package.json').version;
 require('./includedProjections')(proj4);
 module.exports = proj4;

--- a/lib/version.js
+++ b/lib/version.js
@@ -1,1 +1,0 @@
-module.exports = '2.0.0';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "proj4",
-  "version": "2.0.0",
+  "version": "2.1.1-prerelease",
   "description": "Proj4js is a JavaScript library to transform point coordinates from one coordinate system to another, including datum transformations.",
   "main": "lib/index.js",
   "directories": {
@@ -26,18 +26,19 @@
     ]
   },
   "devDependencies": {
-    "grunt-cli": "~0.1.9",
-    "grunt": "~0.4.1",
-    "grunt-contrib-connect": "~0.3.0",
-    "grunt-contrib-jshint": "~0.6.0",
-    "chai": "~1.7.2",
-    "mocha": "~1.12.1",
-    "grunt-mocha-phantomjs": "~0.3.0",
-    "browserify": ">=2.35.0",
-    "grunt-browserify": "~1.2.8",
-    "grunt-contrib-uglify": "~0.2.4",
+    "grunt-cli": "~0.1.13",
+    "grunt": "~0.4.2",
+    "grunt-contrib-connect": "~0.6.0",
+    "grunt-contrib-jshint": "~0.8.0",
+    "chai": "~1.8.1",
+    "mocha": "~1.17.1",
+    "grunt-mocha-phantomjs": "~0.4.0",
+    "browserify": "~3.24.5",
+    "grunt-browserify": "~1.3.0",
+    "grunt-contrib-uglify": "~0.3.2",
     "curl": "git://github.com/cujojs/curl.git",
-    "istanbul": "~0.1.44"
+    "istanbul": "~0.2.4",
+    "tin": "~0.4.0"
   },
   "dependencies": {
     "mgrs": "0.0.0"

--- a/publish.sh
+++ b/publish.sh
@@ -1,17 +1,22 @@
 #!/bin/bash
-#you may need to run npm install -g tin
-tin -v $1
+
+# get current version
+VERSION=$(npm ls --json=true proj4js | grep version | awk '{ print $2}'| sed -e 's/^"//'  -e 's/"$//')
+
+# Build
 git checkout -b build
 grunt
-git add dist
-git add lib/version.js
-git add package.json
-git add bower.json
-git add component.json
-git commit -m build
-git tag $1
-git push --tags git@github.com:proj4js/proj4js.git $1
+git add dist -f
+git commit -m "build $VERSION"
+
+# Tag and push
+git tag $VERSION
+git push --tags git@github.com:proj4js/proj4js.git $VERSION
+
+# Publish
 npm publish
 jam publish
+
+# Cleanup
 git checkout master
 git branch -D build

--- a/test/package.json.js
+++ b/test/package.json.js
@@ -1,0 +1,1 @@
+define({version : "curl is dumb"});


### PR DESCRIPTION
a bunch of minor fixes
- dependencies have been updated
- instead of making the version.js file we just require package.json
- instead of an outdated version in the package/bower/component I took the versioning out of the publish script, we should be doing that ourselves in master (but the upgraded tin allows tin -b minor/major/patch)
- added myself to the license on the grounds it's about time
- updated the change log with this and #92 and #93
