### PR TITLE
Added alternative spelling of osgb36 as osgb_1936 to match PRJ files.

### DIFF
--- a/lib/wkt.js
+++ b/lib/wkt.js
@@ -155,6 +155,9 @@ function cleanWKT(wkt) {
       wkt.a = wkt.GEOGCS.DATUM.SPHEROID.a;
       wkt.rf = parseFloat(wkt.GEOGCS.DATUM.SPHEROID.rf, 10);
     }
+    if (~wkt.datumCode.indexOf('osgb_1936')) {
+	wkt.datumCode = "osgb36";
+    }
   }
   if (wkt.b && !isFinite(wkt.b)) {
     wkt.b = wkt.a;


### PR DESCRIPTION
Fixed a problem with creating an OS Grid transform from a well known text file, where the datum transformation would not be looked up properly.

in WKT format, the datum is D_OSGB_1936, which gets turned internally into osgb_1936. In proj4 format, the datum is OSGB36.

See http://spatialreference.org/ref/epsg/osgb-1936-british-national-grid/esriwkt/ and http://spatialreference.org/ref/epsg/osgb-1936-british-national-grid/proj4/

I've fixed this by creating another copy of the constant with the wkt name, but I don't know the codebase that well, so it may be better to fix this in another place.
