### PR TITLE
Handle datum transformations which are not in the datum constants file

### DIFF
--- a/lib/deriveConstants.js
+++ b/lib/deriveConstants.js
@@ -17,6 +17,8 @@ module.exports = function(json) {
       json.datum_params = datumDef.towgs84 ? datumDef.towgs84.split(',') : null;
       json.ellps = datumDef.ellipse;
       json.datumName = datumDef.datumName ? datumDef.datumName : json.datumCode;
+    } else if (json.towgs84) {
+      json.datum_params = json.towgs84;
     }
   }
   if (!json.a) { // do we have an ellipsoid?

--- a/lib/wkt.js
+++ b/lib/wkt.js
@@ -121,6 +121,9 @@ function cleanWKT(wkt) {
     //}
     if (wkt.GEOGCS.DATUM) {
       wkt.datumCode = wkt.GEOGCS.DATUM.name.toLowerCase();
+      if (wkt.GEOGCS.DATUM.TOWGS84) {
+        wkt.towgs84 = wkt.GEOGCS.DATUM.TOWGS84;
+      }
     }
     else {
       wkt.datumCode = wkt.GEOGCS.name.toLowerCase();


### PR DESCRIPTION
Fixes a problem where, if the datum transformation isn't in our constants file, we always fall back to using the WGS84 datum transformation.

This fix only works for WKT.

Changed wkt.js to extract the GEOGCS.DATUM.TOWGS84 parameter if it
is present.

deriveConstants.js now tries to use the json.towgs84 variable if it cannot find
the datum code. If it cannot find either, it will throw a warning.
