### PR TITLE
Aliased Central Parallel to latitude of origin

### DIFF
--- a/lib/wkt.js
+++ b/lib/wkt.js
@@ -200,7 +200,7 @@ function cleanWKT(wkt) {
   }
 }
 module.exports = function(wkt, self) {
-  var lisp = JSON.parse(("," + wkt).replace(/\s*\,\s*([A-Z_0-9]+?)(\[)/g, ',["$1",').slice(1).replace(/\s*\,\s*([A-Z_0-9]+?)\]/g, ',"$1"]'));
+  var lisp = JSON.parse(("," + wkt).replace(/\s*\,\s*([A-Z_0-9]+?)(\[)/g, ',["$1",').slice(1).replace(/\s*\,\s*([A-Z_0-9]+?)\]/g, ',"$1"]').replace(/,\["VERTCS".+/,''));
   var type = lisp.shift();
   var name = lisp.shift();
   lisp.unshift(['name', name]);


### PR DESCRIPTION
Found a .prj file with a 'Central_Parallel' parameter.
Features weren't aligning correctly in the y axis
Simply aliased 'Central_Parallel' to 'latitude_of_origin' and features projected correctly.  Not sure if this is how it should be handled in the code, but it works.

```
PROJCS["Custom",GEOGCS[
"GCS_North_American_1983",
DATUM[
"D_North_American_1983",
SPHEROID["GRS_1980",6378137.0,298.257222101]
],
PRIMEM["Greenwich",0.0],
UNIT["Degree",0.0174532925199433]
],
PROJECTION["Lambert_Conformal_Conic"],
PARAMETER["False_Easting",1312335.958],
PARAMETER["False_Northing",0.0],
PARAMETER["Central_Meridian",-120.5],
PARAMETER["Standard_Parallel_1",43.0],
PARAMETER["Standard_Parallel_2",45.5],
PARAMETER["Central_Parallel",41.75],
UNIT["Foot",0.3048]]
```
