### PR TITLE
Get character using charAt for IE7 compatibility

### DIFF
--- a/lib/defs.js
+++ b/lib/defs.js
@@ -8,7 +8,7 @@ function defs(name) {
   if (arguments.length === 2) {
     var def = arguments[1];
     if (typeof def === 'string') {
-      if (def[0] === '+') {
+      if (def.charAt(0) === '+') {
         defs[name] = parseProj(arguments[1]);
       }
       else {


### PR DESCRIPTION
Using the additional 2 libraries allows for the latest version of proj4js to work in IE7: 
- https://github.com/es-shims/es5-shim (for the Array.map functions) 
- http://bestiejs.github.io/json3/  (for the missing JSON function)

However there remains one error in IE7 caused by using the bracket notation to access a character rather than the charAt function which is supported by all browsers. This single change allows proj4js to run in IE7 (as far as I have tested it). 

See http://stackoverflow.com/questions/5943726/string-charatx-or-stringx for more details. 
