### PR TITLE
fix: #parse() returns dev-Object as deep-copy instead of reference

### DIFF
--- a/lib/parseCode.js
+++ b/lib/parseCode.js
@@ -20,7 +20,10 @@ function parse(code){
   if (testObj(code)) {
     //check to see if this is a WKT string
     if (testDef(code)) {
-      return defs[code];
+      //return defs[code];
+      //return deep-copy instead of reference
+      //due to performance reasons should be changed to some other deep-copy mechanism
+      return  JSON.parse(JSON.stringify(defs[code]));
     }
     else if (testWKT(code)) {
       return wkt(code);


### PR DESCRIPTION
When using 7-parameter Transformation with a registered dev and proj4 is called more than once, the transformation result is wrong for the second (and following) calls.

Example:
//Without registered dev
var firstProjection = '+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs';
var secondProjection = '+proj=tmerc +lat_0=0 +lon_0=12 +k=1 +x_0=4500000 +y_0=0 +ellps=bessel +units=m +towgs84=601.0,76.0,424.0,0.93293,0.22792,-1.68951,5.7 +no_defs';
console.log('ok: '+proj4(firstProjection, secondProjection,[12,49]));

//With registered dev
proj4.defs("EPSG:31468","+proj=tmerc +lat_0=0 +lon_0=12 +k=1 +x_0=4500000 +y_0=0 +ellps=bessel +towgs84=601.0,76.0,424.0,0.93293,0.22792,-1.68951,5.7 +units=m +no_defs");
//First call
console.log('ok: '+proj4(firstProjection, "EPSG:31468",[12,49]));
//Second call
console.log('wrong: '+proj4(firstProjection, "EPSG:31468",[12,49]));

When proj4 is called, angles and scale -Parameter for the transformation are converted from the registered dev.
Since the properties of the dev-Object itsself (callByReference) are converted, the next call will use the previously modified values as input.
As a solution the dev-Object should be returned as a deep-copy.
