### PR TITLE
Add handling for +units in projString

### DIFF
--- a/lib/constants/units.js
+++ b/lib/constants/units.js
@@ -1,0 +1,2 @@
+exports.ft = {to_meter: 0.3048};
+exports['us-ft'] = {to_meter: 1200 / 3937};

--- a/lib/projString.js
+++ b/lib/projString.js
@@ -1,5 +1,6 @@
 var D2R = 0.01745329251994329577;
 var PrimeMeridian = require('./constants/PrimeMeridian');
+var units = require('./constants/units');
 
 module.exports = function(defData) {
   var self = {};
@@ -81,6 +82,11 @@ module.exports = function(defData) {
     },
     to_meter: function(v) {
       self.to_meter = parseFloat(v);
+    },
+    units: function(v) {
+      if (units[v]) {
+        self.to_meter = units[v].to_meter;
+      }
     },
     from_greenwich: function(v) {
       self.from_greenwich = v * D2R;

--- a/test/testData.js
+++ b/test/testData.js
@@ -285,6 +285,11 @@ var testPoints = [
     ll: [12.806988, 49.452262],
     xy: [-868208.61, -1095793.64]
   },
+  {
+    code:"+proj=tmerc +lat_0=40.5 +lon_0=-110.0833333333333 +k=0.9999375 +x_0=800000.0000101599 +y_0=99999.99998983997 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=us-ft +no_defs",
+    ll: [-110.8, 43.5],
+    xy: [2434515.870, 1422072.711]
+  },
   // check that coordinates at 180 and -180 deg. longitude don't wrap around
   {
     code: 'EPSG:3857',


### PR DESCRIPTION
This adds units constants for ft and us-ft, so the to_meter property can be set properly in the projString parser.