### PR TITLE
Hide download buttons

### DIFF
--- a/stylesheets/stylesheet.css
+++ b/stylesheets/stylesheet.css
@@ -153,9 +153,11 @@ a.button span {
 }
 
 #download-zip span {
+  display: none;
   background: transparent url(../images/zip-icon.png) 12px 50% no-repeat;
 }
 #download-tar-gz span {
+  display: none;
   background: transparent url(../images/tar-gz-icon.png) 12px 50% no-repeat;
 }
 #view-on-github span {


### PR DESCRIPTION
It is misleading to provide a source download in such a prominent place, because people expect the dist files in there.