### PR TITLE
Hide download buttons

### DIFF
--- a/stylesheets/stylesheet.css
+++ b/stylesheets/stylesheet.css
@@ -152,8 +152,14 @@ a.button span {
   padding-left: 50px;
 }
 
+#download-zip {
+	display: none;
+}
 #download-zip span {
   background: transparent url(../images/zip-icon.png) 12px 50% no-repeat;
+}
+#download-tar-gz {
+	display: none;
 }
 #download-tar-gz span {
   background: transparent url(../images/tar-gz-icon.png) 12px 50% no-repeat;


### PR DESCRIPTION
The previous attempt (#177) missed the buttons and only hid the text.