### PR TITLE
Fix IE8 bug caused by exports.null

### DIFF
--- a/lib/constants/grids.js
+++ b/lib/constants/grids.js
@@ -4,7 +4,7 @@
   //        1 is latitude ...
   //        In the later case, grid object gets bigger !!!!
   //        Solution 1 is chosen based on pj_gridinfo.c
-exports.null = { // name of grid's file
+exports['null'] = { // name of grid's file
   "ll": [-3.14159265, - 1.57079633], // lower-left coordinates in radians (longitude, latitude):
   "del": [3.14159265, 1.57079633], // cell's size in radians (longitude, latitude):
   "lim": [3, 3], // number of nodes in longitude, latitude (including edges):


### PR DESCRIPTION
IE8 chokes on `exports.null` in `lib/constants/grids.js` because it gets a bit confused by null meaning _null_. The attached fix doesn't change the structure of the object but it avoids the IE8 issue by putting it in quotes.