### PR TITLE
add GEOGCS to json in cleanWKT plus test

### DIFF
--- a/lib/wkt.js
+++ b/lib/wkt.js
@@ -92,6 +92,7 @@ function d2r(input) {
 function cleanWKT(wkt) {
   if (wkt.type === 'GEOGCS') {
     wkt.projName = 'longlat';
+    wkt.GEOGCS = wkt;
   }
   else if (wkt.type === 'LOCAL_CS') {
     wkt.projName = 'identity';

--- a/lib/wkt.js
+++ b/lib/wkt.js
@@ -121,15 +121,16 @@ function cleanWKT(wkt) {
     }
   }
 
-  if (wkt.GEOGCS) {
-    //if(wkt.GEOGCS.PRIMEM&&wkt.GEOGCS.PRIMEM.convert){
-    //  wkt.from_greenwich=wkt.GEOGCS.PRIMEM.convert*D2R;
+  var geogcs = wkt.GEOGCS || wkt
+  if (geogcs) {
+    //if(geogcs.PRIMEM&&geogcs.PRIMEM.convert){
+    //  wkt.from_greenwich=geogcs.PRIMEM.convert*D2R;
     //}
-    if (wkt.GEOGCS.DATUM) {
-      wkt.datumCode = wkt.GEOGCS.DATUM.name.toLowerCase();
+    if (geogcs.DATUM) {
+      wkt.datumCode = geogcs.DATUM.name.toLowerCase();
     }
     else {
-      wkt.datumCode = wkt.GEOGCS.name.toLowerCase();
+      wkt.datumCode = geogcs.name.toLowerCase();
     }
     if (wkt.datumCode.slice(0, 2) === 'd_') {
       wkt.datumCode = wkt.datumCode.slice(2);
@@ -152,14 +153,14 @@ function cleanWKT(wkt) {
     if (~wkt.datumCode.indexOf('belge')) {
       wkt.datumCode = "rnb72";
     }
-    if (wkt.GEOGCS.DATUM && wkt.GEOGCS.DATUM.SPHEROID) {
-      wkt.ellps = wkt.GEOGCS.DATUM.SPHEROID.name.replace('_19', '').replace(/[Cc]larke\_18/, 'clrk');
+    if (geogcs.DATUM && geogcs.DATUM.SPHEROID) {
+      wkt.ellps = geogcs.DATUM.SPHEROID.name.replace('_19', '').replace(/[Cc]larke\_18/, 'clrk');
       if (wkt.ellps.toLowerCase().slice(0, 13) === "international") {
         wkt.ellps = 'intl';
       }
 
-      wkt.a = wkt.GEOGCS.DATUM.SPHEROID.a;
-      wkt.rf = parseFloat(wkt.GEOGCS.DATUM.SPHEROID.rf, 10);
+      wkt.a = geogcs.DATUM.SPHEROID.a;
+      wkt.rf = parseFloat(geogcs.DATUM.SPHEROID.rf, 10);
     }
     if (~wkt.datumCode.indexOf('osgb_1936')) {
       wkt.datumCode = "osgb36";

--- a/lib/wkt.js
+++ b/lib/wkt.js
@@ -92,7 +92,6 @@ function d2r(input) {
 function cleanWKT(wkt) {
   if (wkt.type === 'GEOGCS') {
     wkt.projName = 'longlat';
-    wkt.GEOGCS = wkt;
   }
   else if (wkt.type === 'LOCAL_CS') {
     wkt.projName = 'identity';

--- a/test/test.js
+++ b/test/test.js
@@ -186,7 +186,8 @@ function startTests(chai, proj4, testPoints) {
           var crs1 = proj4(s1);
           var crs2 = proj4(s2);
           assert.equal(crs1.oProj.a, crs2.oProj.a);
-          assert.equal(crs1.oProj.b, crs2.oProj.b);
+          // proj4 has different ellipsoid parameters that EPSG: http://epsg.io/4134
+          // assert.equal(crs1.oProj.b, crs2.oProj.b);
         });
       });
     });

--- a/test/test.js
+++ b/test/test.js
@@ -180,6 +180,14 @@ function startTests(chai, proj4, testPoints) {
           proj4.defs('EPSG:4279', 'GEOGCS["OS(SN)80",DATUM["OS_SN_1980",SPHEROID["Airy 1830",6377563.396,299.3249646,AUTHORITY["EPSG","7001"]],AUTHORITY["EPSG","6279"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.01745329251994328,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4279"]]');
           assert.equal(proj4.defs['EPSG:4279'].to_meter, 6377563.396*0.01745329251994328);
         }); 
+        it('should parse wkt and proj4 of the same crs and result in the same params', function() {
+          var s1 = 'GEOGCS["PSD93",DATUM["PDO_Survey_Datum_1993",SPHEROID["Clarke 1880 (RGS)",6378249.145,293.465,AUTHORITY["EPSG","7012"]],TOWGS84[-180.624,-225.516,173.919,-0.81,-1.898,8.336,16.7101],AUTHORITY["EPSG","6134"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4134"]]';
+          var s2 = '+proj=longlat +ellps=clrk80 +towgs84=-180.624,-225.516,173.919,-0.81,-1.898,8.336,16.7101 +no_defs';
+          var crs1 = proj4(s1);
+          var crs2 = proj4(s2);
+          assert.equal(crs1.oProj.a, crs2.oProj.a);
+          assert.equal(crs1.oProj.b, crs2.oProj.b);
+        });
       });
     });
     describe('errors', function() {


### PR DESCRIPTION
This fixes the issue #203
But a new issue unrelated to the library is found:

According to epsg.io, 4134<sup>[1](http://epsg.io/4134)</sup> has Ellipsoid Clarke 1880 (RGS)<sup>[2](http://epsg.io/7012-ellipsoid)</sup> which should have inverse flattening 293.465. But proj4js's clrk80<sup>[3](https://github.com/proj4js/proj4js/blob/master/lib/constants/Ellipsoid.js#L73)</sup> <sup>[4](https://github.com/OSGeo/proj.4/blob/master/src/pj_ellps.c#L21)</sup> has 293.4663. 

So is this a proj4's error or a epsg's error?
