### PR TITLE
Remove jam config

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ Depending on your preferences
 ```bash
 npm install proj4
 bower install proj4
-jam install proj4
 component install proj4js/proj4js
 ```
 

--- a/package.json
+++ b/package.json
@@ -16,15 +16,6 @@
   },
   "author": "",
   "license": "MIT",
-  "jam": {
-    "main": "dist/proj4.js",
-    "include": [
-      "dist/proj4.js",
-      "README.md",
-      "AUTHORS",
-      "LICENSE.md"
-    ]
-  },
   "devDependencies": {
     "grunt-cli": "~0.1.13",
     "grunt": "~0.4.2",

--- a/publish.sh
+++ b/publish.sh
@@ -15,7 +15,6 @@ git push --tags git@github.com:proj4js/proj4js.git $VERSION
 
 # Publish
 npm publish
-jam publish
 
 # Cleanup
 git checkout master


### PR DESCRIPTION
As explained in   #208 the Jam-config is used by webpack when requireing/importing proj4. This means that the minifed version is imported, which triggers a webpack-warning.

Jam seems to be discontinued (https://github.com/caolan/jam), so the easiest solution to this problem is to remove the jam-config