### PR TITLE
Fix tmerc / utm projection calculations

### DIFF
--- a/lib/common/adjust_zone.js
+++ b/lib/common/adjust_zone.js
@@ -13,7 +13,7 @@ module.exports = function(zone, lon) {
   }
   else {
     if (zone > 0 && zone <= 60) {
-      return --zone;
+      return zone - 1;
     }
   }
 };

--- a/lib/common/adjust_zone.js
+++ b/lib/common/adjust_zone.js
@@ -1,0 +1,19 @@
+var adjust_lon = require('./adjust_lon');
+
+module.exports = function(zone, lon) {
+  if (!zone) {
+    zone = Math.floor((adjust_lon(lon) + Math.PI) * 30 / Math.PI);
+
+    if (zone < 0) {
+      return 0;
+    }
+    else if (zone >= 60) {
+      return 59;
+    }
+  }
+  else {
+    if (zone > 0 && zone <= 60) {
+      return --zone;
+    }
+  }
+};

--- a/lib/projections/tmerc.js
+++ b/lib/projections/tmerc.js
@@ -13,9 +13,9 @@ exports.init = function() {
 };
 
 /**
-     Transverse Mercator Forward  - long/lat to x/y
-     long/lat in radians
-   */
+    Transverse Mercator Forward  - long/lat to x/y
+    long/lat in radians
+  */
 exports.forward = function(p) {
   var lon = p.x;
   var lat = p.y;
@@ -73,8 +73,8 @@ exports.forward = function(p) {
 };
 
 /**
-     Transverse Mercator Inverse  -  x/y to long/lat
-   */
+    Transverse Mercator Inverse  -  x/y to long/lat
+  */
 exports.inverse = function(p) {
   var con, phi;
   var lat, lon;

--- a/lib/projections/tmerc.js
+++ b/lib/projections/tmerc.js
@@ -10,6 +10,11 @@ var EPSLN = 1.0e-10;
 var sign = require('../common/sign');
 
 exports.init = function() {
+  this.x0 = this.x0 !== undefined ? this.x0 : 0;
+  this.y0 = this.y0 !== undefined ? this.y0 : 0;
+  this.long0 = this.long0 !== undefined ? this.long0 : 0;
+  this.lat0 = this.lat0 !== undefined ? this.lat0 : 0;
+
   if (this.es) {
     this.en = pj_enfn(this.es);
     this.ml0 = pj_mlfn(this.lat0, Math.sin(this.lat0), Math.cos(this.lat0), this.en);
@@ -30,7 +35,7 @@ exports.forward = function(p) {
   var sin_phi = Math.sin(lat);
   var cos_phi = Math.cos(lat);
 
-  if (this.sphere) {
+  if (!this.es) {
     var b = cos_phi * Math.sin(delta_lon);
 
     if ((Math.abs(Math.abs(b) - 1)) < EPSLN) {
@@ -101,7 +106,7 @@ exports.inverse = function(p) {
   var x = (p.x - this.x0) * (1 / this.a);
   var y = (p.y - this.y0) * (1 / this.a);
 
-  if (this.sphere) {
+  if (!this.es) {
     var f = Math.exp(x / this.k0);
     var g = 0.5 * (f - 1 / f);
     var temp = this.lat0 + y / this.k0;

--- a/lib/projections/tmerc.js
+++ b/lib/projections/tmerc.js
@@ -1,3 +1,6 @@
+// Heavily based on this tmerc projection implementation
+// https://github.com/mbloch/mapshaper-proj/blob/master/src/projections/tmerc.js
+
 var pj_enfn = require('../common/pj_enfn');
 var pj_mlfn = require('../common/pj_mlfn');
 var pj_inv_mlfn = require('../common/pj_inv_mlfn');

--- a/lib/projections/tmerc.js
+++ b/lib/projections/tmerc.js
@@ -1,26 +1,19 @@
-var e0fn = require('../common/e0fn');
-var e1fn = require('../common/e1fn');
-var e2fn = require('../common/e2fn');
-var e3fn = require('../common/e3fn');
-var mlfn = require('../common/mlfn');
+var pj_enfn = require('../common/pj_enfn');
+var pj_mlfn = require('../common/pj_mlfn');
+var pj_inv_mlfn = require('../common/pj_inv_mlfn');
 var adjust_lon = require('../common/adjust_lon');
-var HALF_PI = Math.PI/2;
-var EPSLN = 1.0e-10;
 var sign = require('../common/sign');
 var asinz = require('../common/asinz');
 
+var HALF_PI = Math.PI / 2;
+var EPSLN = 1.0e-10;
+
 exports.init = function() {
-  this.e0 = e0fn(this.es);
-  this.e1 = e1fn(this.es);
-  this.e2 = e2fn(this.es);
-  this.e3 = e3fn(this.es);
-  this.ml0 = this.a * mlfn(this.e0, this.e1, this.e2, this.e3, this.lat0);
+  this.en = pj_enfn(this.es);
+  this.ml0 = pj_mlfn(this.lat0, Math.sin(this.lat0), Math.cos(this.lat0), this.en);
 };
 
-/**
-    Transverse Mercator Forward  - long/lat to x/y
-    long/lat in radians
-  */
+// Transverse Mercator Forward - long/lat to x/y (long/lat in radians)
 exports.forward = function(p) {
   var lon = p.x;
   var lat = p.y;
@@ -49,29 +42,37 @@ exports.forward = function(p) {
     var al = cos_phi * delta_lon;
     var als = Math.pow(al, 2);
     var c = this.ep2 * Math.pow(cos_phi, 2);
-    var tq = Math.tan(lat);
+    var cs = Math.pow(c, 2);
+    var tq = Math.abs(cos_phi) > EPSLN ? Math.tan(lat) : 0;
     var t = Math.pow(tq, 2);
+    var ts = Math.pow(t, 2);
     con = 1 - this.es * Math.pow(sin_phi, 2);
-    var n = this.a / Math.sqrt(con);
-    var ml = this.a * mlfn(this.e0, this.e1, this.e2, this.e3, lat);
+    al = al / Math.sqrt(con);
+    var ml = pj_mlfn(lat, sin_phi, cos_phi, this.en);
 
-    x = this.k0 * n * al * (1 + als / 6 * (1 - t + c + als / 20 * (5 - 18 * t + Math.pow(t, 2) + 72 * c - 58 * this.ep2))) + this.x0;
-    y = this.k0 * (ml - this.ml0 + n * tq * (als * (0.5 + als / 24 * (5 - t + 9 * c + 4 * Math.pow(c, 2) + als / 30 * (61 - 58 * t + Math.pow(t, 2) + 600 * c - 330 * this.ep2))))) + this.y0;
+    x = this.a * (this.k0 * al * (1 +
+      als / 6 * (1 - t + c +
+      als / 20 * (5 - 18 * t + ts + 14 * c - 58 * t * c +
+      als / 42 * (61 + 179 * ts - ts * t - 479 * t))))) +
+      this.x0;
 
+    y = this.a * (this.k0 * (ml - this.ml0 +
+      sin_phi * delta_lon * al / 2 * (1 +
+      als / 12 * (5 - t + 9 * c + 4 * cs +
+      als / 30 * (61 + ts - 58 * t + 270 * c - 330 * t * c +
+      als / 56 * (1385 + 543 * ts - ts * t - 3111 * t)))))) +
+      this.y0;
   }
+
   p.x = x;
   p.y = y;
+
   return p;
 };
 
-/**
-    Transverse Mercator Inverse  -  x/y to long/lat
-  */
+// Transverse Mercator Inverse - x/y to long/lat
 exports.inverse = function(p) {
   var con, phi;
-  var delta_phi;
-  var i;
-  var max_iter = 6;
   var lat, lon;
 
   if (this.sphere) {
@@ -91,45 +92,46 @@ exports.inverse = function(p) {
       lon = adjust_lon(Math.atan2(g, h) + this.long0);
     }
   }
-  else { // ellipsoidal form
-    var x = p.x - this.x0;
-    var y = p.y - this.y0;
+  else {
+    var x = (p.x - this.x0) * (1 / this.a);
+    var y = (p.y - this.y0) * (1 / this.a);
 
-    con = (this.ml0 + y / this.k0) / this.a;
-    phi = con;
-    for (i = 0; true; i++) {
-      delta_phi = ((con + this.e1 * Math.sin(2 * phi) - this.e2 * Math.sin(4 * phi) + this.e3 * Math.sin(6 * phi)) / this.e0) - phi;
-      phi += delta_phi;
-      if (Math.abs(delta_phi) <= EPSLN) {
-        break;
-      }
-      if (i >= max_iter) {
-        return (95);
-      }
-    } // for()
+    con = this.ml0 + y / this.k0;
+    phi = pj_inv_mlfn(con, this.es, this.en);
+
     if (Math.abs(phi) < HALF_PI) {
       var sin_phi = Math.sin(phi);
       var cos_phi = Math.cos(phi);
-      var tan_phi = Math.tan(phi);
+      var tan_phi = Math.abs(cos_phi) > EPSLN ? Math.tan(phi) : 0;
       var c = this.ep2 * Math.pow(cos_phi, 2);
       var cs = Math.pow(c, 2);
       var t = Math.pow(tan_phi, 2);
       var ts = Math.pow(t, 2);
       con = 1 - this.es * Math.pow(sin_phi, 2);
-      var n = this.a / Math.sqrt(con);
-      var r = n * (1 - this.es) / con;
-      var d = x / (n * this.k0);
+      var d = x * Math.sqrt(con) / this.k0;
       var ds = Math.pow(d, 2);
-      lat = phi - (n * tan_phi * ds / r) * (0.5 - ds / 24 * (5 + 3 * t + 10 * c - 4 * cs - 9 * this.ep2 - ds / 30 * (61 + 90 * t + 298 * c + 45 * ts - 252 * this.ep2 - 3 * cs)));
-      lon = adjust_lon(this.long0 + (d * (1 - ds / 6 * (1 + 2 * t + c - ds / 20 * (5 - 2 * c + 28 * t - 3 * cs + 8 * this.ep2 + 24 * ts))) / cos_phi));
+      con = con * tan_phi;
+
+      lat = phi - (con * ds / (1 - this.es)) * 0.5 * (1 -
+        ds / 12 * (5 + 3 * t - 9 * c * t + c - 4 * cs -
+        ds / 30 * (61 + 90 * t - 252 * c * t + 45 * ts + 46 * c -
+        ds / 56 * (1385 + 3633 * t + 4095 * ts + 1574 * ts * t))));
+
+      lon = this.long0 + (d * (1 -
+        ds / 6 * (1 + 2 * t + c -
+        ds / 20 * (5 + 28 * t + 24 * ts + 8 * c * t + 6 * c -
+        ds / 42 * (61 + 662 * t + 1320 * ts + 720 * ts * t)))) / cos_phi);
     }
     else {
       lat = HALF_PI * sign(y);
       lon = this.long0;
     }
   }
+
   p.x = lon;
   p.y = lat;
+
   return p;
 };
+
 exports.names = ["Transverse_Mercator", "Transverse Mercator", "tmerc"];

--- a/lib/projections/tmerc.js
+++ b/lib/projections/tmerc.js
@@ -2,18 +2,20 @@ var pj_enfn = require('../common/pj_enfn');
 var pj_mlfn = require('../common/pj_mlfn');
 var pj_inv_mlfn = require('../common/pj_inv_mlfn');
 var adjust_lon = require('../common/adjust_lon');
-var sign = require('../common/sign');
-var asinz = require('../common/asinz');
-
 var HALF_PI = Math.PI / 2;
 var EPSLN = 1.0e-10;
+var sign = require('../common/sign');
+var asinz = require('../common/asinz');
 
 exports.init = function() {
   this.en = pj_enfn(this.es);
   this.ml0 = pj_mlfn(this.lat0, Math.sin(this.lat0), Math.cos(this.lat0), this.en);
 };
 
-// Transverse Mercator Forward - long/lat to x/y (long/lat in radians)
+/**
+     Transverse Mercator Forward  - long/lat to x/y
+     long/lat in radians
+   */
 exports.forward = function(p) {
   var lon = p.x;
   var lat = p.y;
@@ -70,7 +72,9 @@ exports.forward = function(p) {
   return p;
 };
 
-// Transverse Mercator Inverse - x/y to long/lat
+/**
+     Transverse Mercator Inverse  -  x/y to long/lat
+   */
 exports.inverse = function(p) {
   var con, phi;
   var lat, lon;
@@ -92,7 +96,7 @@ exports.inverse = function(p) {
       lon = adjust_lon(Math.atan2(g, h) + this.long0);
     }
   }
-  else {
+  else { // ellipsoidal form
     var x = (p.x - this.x0) * (1 / this.a);
     var y = (p.y - this.y0) * (1 / this.a);
 

--- a/lib/projections/tmerc.js
+++ b/lib/projections/tmerc.js
@@ -5,11 +5,12 @@ var adjust_lon = require('../common/adjust_lon');
 var HALF_PI = Math.PI / 2;
 var EPSLN = 1.0e-10;
 var sign = require('../common/sign');
-var asinz = require('../common/asinz');
 
 exports.init = function() {
-  this.en = pj_enfn(this.es);
-  this.ml0 = pj_mlfn(this.lat0, Math.sin(this.lat0), Math.cos(this.lat0), this.en);
+  if (this.es) {
+    this.en = pj_enfn(this.es);
+    this.ml0 = pj_mlfn(this.lat0, Math.sin(this.lat0), Math.cos(this.lat0), this.en);
+  }
 };
 
 /**
@@ -28,16 +29,32 @@ exports.forward = function(p) {
 
   if (this.sphere) {
     var b = cos_phi * Math.sin(delta_lon);
-    if ((Math.abs(Math.abs(b) - 1)) < 0.0000000001) {
+
+    if ((Math.abs(Math.abs(b) - 1)) < EPSLN) {
       return (93);
     }
     else {
-      x = 0.5 * this.a * this.k0 * Math.log((1 + b) / (1 - b));
-      con = Math.acos(cos_phi * Math.cos(delta_lon) / Math.sqrt(1 - b * b));
-      if (lat < 0) {
-        con = -con;
+      x = 0.5 * this.a * this.k0 * Math.log((1 + b) / (1 - b)) + this.x0;
+      y = cos_phi * Math.cos(delta_lon) / Math.sqrt(1 - Math.pow(b, 2));
+      b = Math.abs(y);
+
+      if (b >= 1) {
+        if ((b - 1) > EPSLN) {
+          return (93);
+        }
+        else {
+          y = 0;
+        }
       }
-      y = this.a * this.k0 * (con - this.lat0);
+      else {
+        y = Math.acos(y);
+      }
+
+      if (lat < 0) {
+        y = -y;
+      }
+
+      y = this.a * this.k0 * (y - this.lat0) + this.y0;
     }
   }
   else {
@@ -78,28 +95,29 @@ exports.forward = function(p) {
 exports.inverse = function(p) {
   var con, phi;
   var lat, lon;
+  var x = (p.x - this.x0) * (1 / this.a);
+  var y = (p.y - this.y0) * (1 / this.a);
 
   if (this.sphere) {
-    var f = Math.exp(p.x / (this.a * this.k0));
+    var f = Math.exp(x / this.k0);
     var g = 0.5 * (f - 1 / f);
-    var temp = this.lat0 + p.y / (this.a * this.k0);
+    var temp = this.lat0 + y / this.k0;
     var h = Math.cos(temp);
-    con = Math.sqrt((1 - h * h) / (1 + g * g));
-    lat = asinz(con);
-    if (temp < 0) {
+    con = Math.sqrt((1 - Math.pow(h, 2)) / (1 + Math.pow(g, 2)));
+    lat = Math.asin(con);
+
+    if (y < 0) {
       lat = -lat;
     }
+
     if ((g === 0) && (h === 0)) {
-      lon = this.long0;
+      lon = 0;
     }
     else {
       lon = adjust_lon(Math.atan2(g, h) + this.long0);
     }
   }
   else { // ellipsoidal form
-    var x = (p.x - this.x0) * (1 / this.a);
-    var y = (p.y - this.y0) * (1 / this.a);
-
     con = this.ml0 + y / this.k0;
     phi = pj_inv_mlfn(con, this.es, this.en);
 
@@ -121,14 +139,14 @@ exports.inverse = function(p) {
         ds / 30 * (61 + 90 * t - 252 * c * t + 45 * ts + 46 * c -
         ds / 56 * (1385 + 3633 * t + 4095 * ts + 1574 * ts * t))));
 
-      lon = this.long0 + (d * (1 -
+      lon = adjust_lon(this.long0 + (d * (1 -
         ds / 6 * (1 + 2 * t + c -
         ds / 20 * (5 + 28 * t + 24 * ts + 8 * c * t + 6 * c -
-        ds / 42 * (61 + 662 * t + 1320 * ts + 720 * ts * t)))) / cos_phi);
+        ds / 42 * (61 + 662 * t + 1320 * ts + 720 * ts * t)))) / cos_phi));
     }
     else {
       lat = HALF_PI * sign(y);
-      lon = this.long0;
+      lon = 0;
     }
   }
 

--- a/lib/projections/utm.js
+++ b/lib/projections/utm.js
@@ -1,12 +1,16 @@
-var D2R = 0.01745329251994329577;
+var adjust_zone = require('../common/adjust_zone');
 var tmerc = require('./tmerc');
+
 exports.dependsOn = 'tmerc';
+
 exports.init = function() {
-  if (!this.zone) {
+  var zone = adjust_zone(this.zone, this.long0);
+  if (!zone) {
     return;
   }
+
   this.lat0 = 0;
-  this.long0 = ((6 * Math.abs(this.zone)) - 183) * D2R;
+  this.long0 = (zone + 0.5) * Math.PI / 30 - Math.PI;
   this.x0 = 500000;
   this.y0 = this.utmSouth ? 10000000 : 0;
   this.k0 = 0.9996;
@@ -15,4 +19,5 @@ exports.init = function() {
   this.forward = tmerc.forward;
   this.inverse = tmerc.inverse;
 };
+
 exports.names = ["Universal Transverse Mercator System", "utm"];

--- a/test/test.js
+++ b/test/test.js
@@ -25,17 +25,18 @@ function startTests(chai, proj4, testPoints) {
       var sweref99tm = '+proj=utm +zone=33 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs';
       var rt90 = '+lon_0=15.808277777799999 +lat_0=0.0 +k=1.0 +x_0=1500000.0 +y_0=0.0 +proj=tmerc +ellps=bessel +units=m +towgs84=414.1,41.3,603.1,-0.855,2.141,-7.023,0 +no_defs';
       var rslt = proj4(sweref99tm, rt90).forward([319180, 6399862]);
-      assert.closeTo(rslt[0], 1271137.927154, 0.000001);
-      assert.closeTo(rslt[1], 6404230.291456, 0.000001);
+      assert.closeTo(rslt[0], 1271137.9275601401, 0.000001);
+      assert.closeTo(rslt[1], 6404230.291448903, 0.000001);
     });
     it('should work with a proj object', function() {
       var sweref99tm = proj4('+proj=utm +zone=33 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs');
       var rt90 = proj4('+lon_0=15.808277777799999 +lat_0=0.0 +k=1.0 +x_0=1500000.0 +y_0=0.0 +proj=tmerc +ellps=bessel +units=m +towgs84=414.1,41.3,603.1,-0.855,2.141,-7.023,0 +no_defs');
       var rslt = proj4(sweref99tm, rt90).forward([319180, 6399862]);
-      assert.closeTo(rslt[0], 1271137.927154, 0.000001);
-      assert.closeTo(rslt[1], 6404230.291456, 0.000001);
+      assert.closeTo(rslt[0], 1271137.9275601401, 0.000001);
+      assert.closeTo(rslt[1], 6404230.291448903, 0.000001);
     });
   });
+
   describe('proj4', function() {
     describe('core', function() {
       testPoints.forEach(function(testPoint) {

--- a/test/testData.js
+++ b/test/testData.js
@@ -147,20 +147,20 @@ var testPoints = [
   {
     code:'PROJCS["Beduaram / TM 13 NE",GEOGCS["Beduaram",DATUM["Beduaram",SPHEROID["Clarke 1880 (IGN)",6378249.2,293.4660212936269,AUTHORITY["EPSG","7011"]],TOWGS84[-106,-87,188,0,0,0,0],AUTHORITY["EPSG","6213"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.01745329251994328,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4213"]],UNIT["metre",1,AUTHORITY["EPSG","9001"]],PROJECTION["Transverse_Mercator"],PARAMETER["latitude_of_origin",0],PARAMETER["central_meridian",13],PARAMETER["scale_factor",0.9996],PARAMETER["false_easting",500000],PARAMETER["false_northing",0],AUTHORITY["EPSG","2931"],AXIS["X",EAST],AXIS["Y",NORTH]]',
     ll:[5, 25],
-    xy:[-308919.1462828873, 2788738.252386554],
+    xy:[-308919.1234711099, 2788738.255936392],
     acc:{
       ll:5
     }
   },
-   {
+  {
     code:'PROJCS["Beduaram / TM 13 NE",GEOGCS["Beduaram",DATUM["D_Beduaram",SPHEROID["Clarke_1880_IGN",6378249.2,293.4660212936269]],PRIMEM["Greenwich",0],UNIT["Degree",0.017453292519943295]],PROJECTION["Transverse_Mercator"],PARAMETER["latitude_of_origin",0],PARAMETER["central_meridian",13],PARAMETER["scale_factor",0.9996],PARAMETER["false_easting",500000],PARAMETER["false_northing",0],UNIT["Meter",1]]',
     ll:[5, 25],
-    xy:[-308919.1462828873, 2788738.252386554],
+    xy:[-308919.1234711099, 2788738.255936392],
     acc:{
       ll:5
     }
-  }
-  ,{
+  },
+  {
     code:'PROJCS["S-JTSK (Ferro) / Krovak",GEOGCS["S-JTSK (Ferro)",DATUM["S_JTSK_Ferro",SPHEROID["Bessel 1841",6377397.155,299.1528128,AUTHORITY["EPSG","7004"]],AUTHORITY["EPSG","6818"]],PRIMEM["Ferro",-17.66666666666667,AUTHORITY["EPSG","8909"]],UNIT["degree",0.01745329251994328,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4818"]],UNIT["metre",1,AUTHORITY["EPSG","9001"]],PROJECTION["Krovak"],PARAMETER["latitude_of_center",49.5],PARAMETER["longitude_of_center",42.5],PARAMETER["azimuth",30.28813972222222],PARAMETER["pseudo_standard_parallel_1",78.5],PARAMETER["scale_factor",0.9999],PARAMETER["false_easting",0],PARAMETER["false_northing",0],AUTHORITY["EPSG","2065"],AXIS["Y",WEST],AXIS["X",SOUTH]]',
     ll:[17.323583231075897, 49.39440725405376],
     xy:[-544115.474379, -1144058.330762]

--- a/test/testData.js
+++ b/test/testData.js
@@ -308,6 +308,80 @@ var testPoints = [
     code: 'EPSG:3857',
     ll: [180, 0],
     xy: [20037508.342789, 0]
+  },
+  // these test cases are taken from mapshaper-proj and the test results match
+  {
+    code: '+proj=tmerc +ellps=GRS80 +lat_1=0.5 +lat_2=2 +n=0.5',
+    ll: [2, 1],
+    xy: [222650.79679577847, 110642.2294119271]
+  },
+  {
+    code: '+proj=tmerc +a=6400000 +lat_1=0.5 +lat_2=2 +n=0.5 +datum=none',
+    ll: [2, 1],
+    xy: [223413.46640632232, 111769.14504059685]
+  },
+  {
+    code: '+proj=utm +zone=30 +ellps=GRS80 +lat_1=0.5 +lat_2=2 +n=0.5',
+    ll: [2, 1],
+    xy: [1057002.4052152266, 110955.14117382761]
+  },
+  // these test cases are related to the original issue on GitHub
+  {
+    code: '+proj=utm +zone=33 +datum=WGS84 +units=m +no_defs',
+    ll: [2, 1],
+    xy: [-959006.3439168662, 113457.31706492987],
+    acc: {
+      ll: 5
+    }
+  },
+  {
+    code: '+proj=utm +zone=33 +datum=WGS84 +units=m +no_defs',
+    ll: [31, 70],
+    xy: [1104629.4280255223, 7845845.076400871],
+    acc: {
+      ll: 4
+    }
+  },
+  // these test cases are for Norway snow flake zones
+  {
+    code: '+proj=utm +zone=31 +datum=WGS84 +units=m +no_defs',
+    ll: [59.121778, 1.508527],
+    xy: [8055639.601582392, 297536.7150416747],
+    acc: {
+      ll: 0
+    }
+  },
+  {
+    code: '+proj=utm +zone=32 +datum=WGS84 +units=m +no_defs',
+    ll: [59.121778, 1.508527],
+    xy: [6958363.797581035, 260155.3254079497],
+    acc: {
+      ll: 0
+    }
+  },
+  {
+    code: '+proj=utm +zone=33 +datum=WGS84 +units=m +no_defs',
+    ll: [59.121778, 1.508527],
+    xy: [5980907.454031456, 232674.60895515585],
+    acc: {
+      ll: 1
+    }
+  },
+  {
+    code: '+proj=utm +zone=34 +datum=WGS84 +units=m +no_defs',
+    ll: [79.070672, 20.520579],
+    xy: [7442887.111291251, 3910285.3071145327],
+    acc: {
+      ll: -1.5
+    }
+  },
+  {
+    code: '+proj=utm +zone=35 +datum=WGS84 +units=m +no_defs',
+    ll: [79.070672, 20.520579],
+    xy: [6555309.538050345, 3474309.0216152733],
+    acc: {
+      ll: -0.5
+    }
   }
 ];
 if(typeof module !== 'undefined'){


### PR DESCRIPTION
Reason of doing this is because calculation results for `proj4js` and `cs2cs` differed by a large margin and it meant that there is an issue in the `tmerc` projection calculations.

More details here https://github.com/proj4js/proj4js/issues/187

Hugely inspired by `mapshaper-proj` and how `tmerc` projection is calculated there https://github.com/mbloch/mapshaper-proj/blob/master/src/projections/tmerc.js

- Added common function to adjust zone, called adjust_zone
- Fixed `tmerc` / `utm` projection calculations that were not accurate enough
- Adjusted test data for the more precise calculations