### PR TITLE
Fix running istanbul on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "doc": "docs"
   },
   "scripts": {
-    "test": "./node_modules/istanbul/lib/cli.js test ./node_modules/mocha/bin/_mocha test/test.js"
+    "test": "istanbul test ./node_modules/mocha/bin/_mocha test/test.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Because npm is aware of package executables, such as `istanbul`, using the full path is not necessary, moreover it is not platform independent. The test script (`npm test`) failed on Windows because of this. This issue can be resolved by simply calling `istanbul` without the full path.

Note that the "mocha" argument supplied to `istanbul` still requires the full path because of the way it is being used.