### PR TITLE
fix floating point reversion (#237)

### DIFF
--- a/lib/common/adjust_zone.js
+++ b/lib/common/adjust_zone.js
@@ -2,17 +2,13 @@ import adjust_lon from './adjust_lon';
 
 export default function(zone, lon) {
   if (zone === undefined) {
-    zone = Math.floor((adjust_lon(lon) + Math.PI) * 30 / Math.PI);
+    zone = Math.floor((adjust_lon(lon) + Math.PI) * 30 / Math.PI) + 1;
 
     if (zone < 0) {
       return 0;
-    } else if (zone >= 60) {
-      return 59;
-    }
-    return zone;
-  } else {
-    if (zone > 0 && zone <= 60) {
-      return zone - 1;
+    } else if (zone > 60) {
+      return 60;
     }
   }
+  return zone;
 }

--- a/lib/projections/etmerc.js
+++ b/lib/projections/etmerc.js
@@ -85,7 +85,6 @@ export function forward(p) {
   var Cn = p.y;
 
   Cn = gatg(this.cbg, Cn);
-
   var sin_Cn = Math.sin(Cn);
   var cos_Cn = Math.cos(Cn);
   var sin_Ce = Math.sin(Ce);

--- a/lib/projections/utm.js
+++ b/lib/projections/utm.js
@@ -1,6 +1,7 @@
 import adjust_zone from '../common/adjust_zone';
 import etmerc from './etmerc';
 export var dependsOn = 'etmerc';
+import {D2R} from '../constants/values';
 
 
 export function init() {
@@ -8,9 +9,8 @@ export function init() {
   if (zone === undefined) {
     throw new Error('unknown utm zone');
   }
-
   this.lat0 = 0;
-  this.long0 = (zone + 0.5) * Math.PI / 30 - Math.PI;
+  this.long0 =  ((6 * Math.abs(zone)) - 183) * D2R;
   this.x0 = 500000;
   this.y0 = this.utmSouth ? 10000000 : 0;
   this.k0 = 0.9996;

--- a/package.json
+++ b/package.json
@@ -38,6 +38,6 @@
   },
   "dependencies": {
     "mgrs": "1.0.0",
-    "wkt-parser": "^1.1.2"
+    "wkt-parser": "^1.1.3"
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -180,7 +180,22 @@ function startTests(chai, proj4, testPoints) {
 
           proj4.defs('EPSG:4279', 'GEOGCS["OS(SN)80",DATUM["OS_SN_1980",SPHEROID["Airy 1830",6377563.396,299.3249646,AUTHORITY["EPSG","7001"]],AUTHORITY["EPSG","6279"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.01745329251994328,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4279"]]');
           assert.equal(proj4.defs['EPSG:4279'].to_meter, 6377563.396*0.01745329251994328);
-        }); 
+        });
+        it('should parse wkt and proj4 of the same crs and result in the same params', function() {
+          var s1 = 'GEOGCS["PSD93",DATUM["PDO_Survey_Datum_1993",SPHEROID["Clarke 1880 (RGS)",6378249.145,293.465,AUTHORITY["EPSG","7012"]],TOWGS84[-180.624,-225.516,173.919,-0.81,-1.898,8.336,16.7101],AUTHORITY["EPSG","6134"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4134"]]';
+          var s2 = '+proj=longlat +ellps=clrk80 +towgs84=-180.624,-225.516,173.919,-0.81,-1.898,8.336,16.7101 +no_defs';
+          var crs1 = proj4(s1);
+          var crs2 = proj4(s2);
+          assert.equal(crs1.oProj.a, crs2.oProj.a);
+          // proj4 has different ellipsoid parameters that EPSG: http://epsg.io/4134
+          // assert.equal(crs1.oProj.b, crs2.oProj.b);
+        });
+        it('should handled defined points correctly', function () {
+          var prj = '+proj=utm +zone=31';
+          var proj = proj4(prj);
+          var res = proj.forward([3, 0]);
+          assert.deepEqual(res, [500000, 0]);
+        });
       });
     });
     describe('errors', function() {


### PR DESCRIPTION
paging @theashyster as this effects some code he wrote, basically what he did involved a formula that for some reason required the zone to be one lower then it really was but also seemed to have a floating point error in it, so this reverts to the old formula which doesn't require the zone to be one less so that's why it touches the the adjust lon stuff, I probably need some tests to check zones 0 and 60 while I'm at it