### PR TITLE
An included Typescript definitions file

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Proj4js is a JavaScript library to transform point coordinates from one coordinate system to another, including datum transformations.",
   "main": "dist/proj4-src.js",
   "module": "lib/index.js",
+  "typings": "proj4.d.ts",
   "directories": {
     "test": "test",
     "doc": "docs"

--- a/proj4.d.ts
+++ b/proj4.d.ts
@@ -1,0 +1,67 @@
+// Type definitions for proj4 2.3
+// Project: https://github.com/proj4js/proj4js
+// Definitions by: Denis Carriere <https://github.com/DenisCarriere>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare namespace proj4 {
+    type TemplateCoordinates = number[] | InterfaceCoordinates;
+
+    interface InterfaceCoordinates {
+        x: number;
+        y: number;
+        z?: number;
+        m?: number;
+    }
+
+    interface InterfaceDatum {
+        datum_type: number;
+        a: number;
+        b: number;
+        es: number;
+        ep2: number;
+    }
+
+    interface Static {
+        forward(coordinates: InterfaceCoordinates): InterfaceCoordinates;
+        inverse(coordinates: InterfaceCoordinates): InterfaceCoordinates;
+    }
+
+    interface InterfaceProjection {
+        datum: string;
+        b: number;
+        rf: number;
+        sphere: number;
+        es: number;
+        e: number;
+        ep2: number;
+        forward(coordinates: InterfaceCoordinates): InterfaceCoordinates;
+        inverse(coordinates: InterfaceCoordinates): InterfaceCoordinates;
+    }
+
+    export const defaultDatum: string;
+
+    export function Proj(srsCode: any, callback?: any): InterfaceProjection;
+
+    export const WGS84: any;
+
+    /**
+     * Depecrated v3
+     */
+    export function Point(x: number, y: number, z?: number): InterfaceCoordinates;
+    export function Point(coordinates: TemplateCoordinates | string): InterfaceCoordinates;
+
+    export function toPoint(array: number[]): InterfaceCoordinates;
+
+    export function defs(name: string, projection?: string): any;
+    export function defs(name: string[][]): any;
+
+    export function transform(source: InterfaceProjection, dest: InterfaceProjection, point: TemplateCoordinates): any;
+
+    export function mgrs(coordinates: number[], accuracy: number): string;
+
+    export const version: string;
+}
+
+declare function proj4(fromProjection: string, toProjection?: string, coordinates?: proj4.TemplateCoordinates): proj4.Static;
+declare function proj4(fromProjection: string, coordinates: proj4.TemplateCoordinates): number[];
+export default proj4;


### PR DESCRIPTION
As stated in Typescript documentation [1], it's favourable to
have the definitions file alongside the source.

As far I know, definition files on _Definitely Typed_  aren't versioned and it's easy to end up using a version of an NPM package that doesn't match its definitions on DT -- I've been there :)

The file here is based on the work done by @DenisCarriere and I'd be glad to hear your opinion on such a setup. 

[1] http://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html

