### PR TITLE
Fix error when geodeticToGeocentric returns null

### DIFF
--- a/lib/datumUtils.js
+++ b/lib/datumUtils.js
@@ -48,10 +48,13 @@ export function geodeticToGeocentric(p, es, a) {
     Latitude = -HALF_PI;
   } else if (Latitude > HALF_PI && Latitude < 1.001 * HALF_PI) {
     Latitude = HALF_PI;
-  } else if ((Latitude < -HALF_PI) || (Latitude > HALF_PI)) {
+  } else if (Latitude < -HALF_PI) {
     /* Latitude out of range */
     //..reportError('geocent:lat out of range:' + Latitude);
-    return null;
+    return { x: -Infinity, y: -Infinity, z: p.z };
+  } else if (Latitude > HALF_PI) {
+    /* Latitude out of range */
+    return { x: Infinity, y: Infinity, z: p.z };
   }
 
   if (Longitude > Math.PI) {


### PR DESCRIPTION
JS execution stops when geodeticToGeocentric returns null point and throws exception that p is null. 
I think it will be much better if it returns somehow like in c++ proj4 function pj_geodetic_to_geocentric.c:409.
At least in openlayers when View proj is EPSG:28405 but Layer proj is EPSG:3857 it will draw something, not just stop on exception.
Without fix:
![ol 28405 bug proj](https://user-images.githubusercontent.com/2876833/27218884-65fd5f74-5288-11e7-9524-025a66f3427b.png)
With fix:
![ol 28405](https://user-images.githubusercontent.com/2876833/27218879-5fe941d4-5288-11e7-8675-38b426ae90c6.png)
