### PR TITLE
Improve TypeScript support

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -18,4 +18,12 @@ proj4.transform = transform;
 proj4.mgrs = mgrs;
 proj4.version = version;
 includedProjections(proj4);
+
+/*
+ * Fix importing in typescript after rollup compilation
+ * https://github.com/rollup/rollup/issues/1156
+ * https://github.com/Microsoft/TypeScript/issues/13017#issuecomment-268657860
+ */
+proj4.default = proj4;
+
 export default proj4;


### PR DESCRIPTION
If I want to consume proj4js in a TypeScript Node.js environment I currently have to import it like that:

```javascript
import * as proj4 from 'proj4';
```

If I use it with webpack in a browser:

```javascript
import proj4 from 'proj4';
```

Which is troublesome in a library which can be used in a browser and Node.js.

Fix inspired by:
https://github.com/paypal/glamorous/pull/104