### PR TITLE
parsing updates

### DIFF
--- a/lib/parseCode.js
+++ b/lib/parseCode.js
@@ -1,17 +1,34 @@
 import defs from './defs';
 import wkt from 'wkt-parser';
 import projStr from './projString';
+import match from './match';
 function testObj(code){
   return typeof code === 'string';
 }
 function testDef(code){
   return code in defs;
 }
- var codeWords = ['PROJECTEDCRS', 'PROJCRS', 'GEOGCS','GEOCCS','PROJCS','LOCAL_CS', 'GEODCRS', 'GEODETICCRS', 'GEODETICDATUM', 'ENGCRS', 'ENGINEERINGCRS']; 
+ var codeWords = ['PROJECTEDCRS', 'PROJCRS', 'GEOGCS','GEOCCS','PROJCS','LOCAL_CS', 'GEODCRS', 'GEODETICCRS', 'GEODETICDATUM', 'ENGCRS', 'ENGINEERINGCRS'];
 function testWKT(code){
   return codeWords.some(function (word) {
     return code.indexOf(word) > -1;
   });
+}
+var codes = ['3857', '900913', '3785', '102113'];
+function checkMercator(item) {
+  var auth = match(item, 'authority');
+  if (!auth) {
+    return;
+  }
+  var code = match(auth, 'epsg');
+  return code && codes.indexOf(code) > -1;
+}
+function checkProjStr(item) {
+  var ext = match(item, 'extension');
+  if (!ext) {
+    return;
+  }
+  return match(ext, 'proj4');
 }
 function testProj(code){
   return code[0] === '+';
@@ -23,7 +40,16 @@ function parse(code){
       return defs[code];
     }
     if (testWKT(code)) {
-      return wkt(code);
+      var out = wkt(code);
+      // test of spetial case, due to this being a very common and often malformed
+      if (checkMercator(out)) {
+        return defs['EPSG:3857'];
+      }
+      var maybeProjStr = checkProjStr(out);
+      if (maybeProjStr) {
+        return projStr(maybeProjStr);
+      }
+      return out;
     }
     if (testProj(code)) {
       return projStr(code);

--- a/test/testData.js
+++ b/test/testData.js
@@ -507,14 +507,14 @@ var testPoints = [
     xy: [-959006.4926646841, 113457.31956265299]
   },
   {
-    code: '+proj=moll +lon_0=0 +x_0=0 +y_0=0 +datum=WGS84 +units=m +no_defs',
-    ll: [-180, 80.11],
-    xy: [-5837753.259051185, 8534718.648155002]
+    code: 'PROJCS["WGS 84 / Pseudo-Mercator", GEOGCS["WGS 84", DATUM["World Geodetic System 1984", SPHEROID["WGS 84", 6378137.0, 0, AUTHORITY["EPSG","7030"]], AUTHORITY["EPSG","6326"]], PRIMEM["Greenwich", 0.0, AUTHORITY["EPSG","8901"]], UNIT["degree", 0.017453292519943295], AXIS["Geodetic latitude", NORTH], AXIS["Geodetic longitude", EAST], AUTHORITY["EPSG","4326"]], PROJECTION["Popular Visualisation Pseudo Mercator", AUTHORITY["EPSG","1024"]], PARAMETER["semi_minor", 6378137.0], PARAMETER["latitude_of_origin", 0.0], PARAMETER["central_meridian", 0.0], PARAMETER["scale_factor", 1.0], PARAMETER["false_easting", 0.0], PARAMETER["false_northing", 0.0], UNIT["m", 1.0], AXIS["Easting", EAST], AXIS["Northing", NORTH], AUTHORITY["EPSG","3857"]]',
+    xy: [-12523490.49256873, 5166512.50707369],
+    ll: [-112.50042920000004,42.036926809999976]
   },
   {
-    code: '+proj=moll +lon_0=0 +x_0=0 +y_0=0 +datum=WGS84 +units=m',
-    ll: [-180, 80],
-    xy: [-5879879.246669655, 8527486.041776998]
+    code: 'PROJCS["WGS 84 / Pseudo-Mercator",GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4326"]],PROJECTION["Mercator_1SP"],PARAMETER["central_meridian",0],PARAMETER["scale_factor",1],PARAMETER["false_easting",0],PARAMETER["false_northing",0],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["X",EAST],AXIS["Y",NORTH],EXTENSION["PROJ4","+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext  +no_defs"],AUTHORITY["EPSG","9999"]]',
+    xy: [-12523490.49256873, 5166512.50707369],
+    ll: [-112.50042920000004,42.036926809999976]
   }
 ];
 if(typeof module !== 'undefined'){


### PR DESCRIPTION
2 fixes here, first if a proj string is defined in the wkt, lets prefer that as it's probably more accurate (from our perspective), (fixes #272), next lets look if it's spherical Mercator and if it is, lets just grab our predifined version of that as not all the wkt actually bother to say it needs to be spherical (Fixes #220)