### PR TITLE
#292 added support for DHDN Datum

### DIFF
--- a/lib/constants/Datum.js
+++ b/lib/constants/Datum.js
@@ -101,3 +101,9 @@ exports.rnb72 = {
   ellipse: "intl",
   datumName: "Reseau National Belge 1972"
 };
+
+exports.deutsches_hauptdreiecksnetz = {
+  towgs84: "598.1,73.7,418.2,0.202,0.045,-2.455,6.7"
+  ellipse: "bessel",
+  datumName: "Deutsches_Hauptdreiecksnetz"
+};


### PR DESCRIPTION
Datum "DHDN / Deutsches Hauptdreiecksnetz" is used for the Gauss-Kruger coordinate systems used previously by german administrative offices. `towgs84` parameter values were taken from [epsg.io](https://epsg.io/31468)