### PR TITLE
Addition to #230, added support for array coords

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -105,7 +105,7 @@ module.exports = function(grunt) {
       }).join("\n"),
       "export default function(proj4){",
       projections.map(function(proj) {
-        return "  proj4.Proj.projections.add(" + proj + ");"
+        return "  proj4.Proj.projections.add(" + proj + ");";
       }).join("\n"),
       "}"
     ].join("\n"));

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -105,7 +105,7 @@ module.exports = function(grunt) {
       }).join("\n"),
       "export default function(proj4){",
       projections.map(function(proj) {
-        return "  proj4.Proj.projections.add(" + proj + ");";
+        return "  proj4.Proj.projections.add(" + proj + ");"
       }).join("\n"),
       "}"
     ].join("\n"));

--- a/lib/core.js
+++ b/lib/core.js
@@ -6,15 +6,7 @@ function transformer(from, to, coords) {
   var transformedArray, out, keys;
   if (Array.isArray(coords)) {
     transformedArray = transform(from, to, coords);
-    if (coords.length === 3) {
-      return [transformedArray.x, transformedArray.y, coords[2]];
-    }
-    else if (coords.length === 4) {
-      return [transformedArray.x, transformedArray.y, coords[2], coords[3]];
-    }
-    else {
-      return [transformedArray.x, transformedArray.y];
-    }
+    return [transformedArray.x, transformedArray.y].concat(coords.splice(2));
   }
   else {
     out = transform(from, to, coords);

--- a/lib/core.js
+++ b/lib/core.js
@@ -7,7 +7,10 @@ function transformer(from, to, coords) {
   if (Array.isArray(coords)) {
     transformedArray = transform(from, to, coords);
     if (coords.length === 3) {
-      return [transformedArray.x, transformedArray.y, transformedArray.z];
+      return [transformedArray.x, transformedArray.y, coords[2]];
+    }
+    else if (coords.length === 4) {
+      return [transformedArray.x, transformedArray.y, coords[2], coords[3]];
     }
     else {
       return [transformedArray.x, transformedArray.y];

--- a/lib/core.js
+++ b/lib/core.js
@@ -6,7 +6,12 @@ function transformer(from, to, coords) {
   var transformedArray, out, keys;
   if (Array.isArray(coords)) {
     transformedArray = transform(from, to, coords);
-    return [transformedArray.x, transformedArray.y].concat(coords.splice(2));
+    if (coords.length > 2) {
+      return [transformedArray.x, transformedArray.y].concat(coords.splice(2));
+    }
+    else {
+      return [transformedArray.x, transformedArray.y];
+    }
   }
   else {
     out = transform(from, to, coords);

--- a/test/test.js
+++ b/test/test.js
@@ -187,6 +187,22 @@ function startTests(chai, proj4, testPoints) {
           assert.equal(rslt.method(), 'correct answer');
       });
     });
+    describe('points array', function () {
+      it('should ignore stuff it does not know', function (){
+        var sweref99tm = '+proj=utm +zone=33 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs';
+        var rt90 = '+lon_0=15.808277777799999 +lat_0=0.0 +k=1.0 +x_0=1500000.0 +y_0=0.0 +proj=tmerc +ellps=bessel +units=m +towgs84=414.1,41.3,603.1,-0.855,2.141,-7.023,0 +no_defs';
+        var rslt = proj4(sweref99tm, rt90).forward([
+          319180,
+          6399862,
+          0,
+          1000
+        ]);
+        assert.closeTo(rslt[0], 1271137.9275601401, 0.000001);
+        assert.closeTo(rslt[1], 6404230.291459564, 0.000001);
+        assert.equal(rslt[2], 0);
+        assert.equal(rslt[3], 1000);
+      });
+    });
     describe('defs', function() {
       assert.equal(proj4.defs('testmerc'), proj4.defs['testmerc']);
       proj4.defs('foo', '+proj=merc +lon_0=5.937 +lat_ts=45.027 +ellps=sphere');

--- a/test/test.js
+++ b/test/test.js
@@ -195,7 +195,7 @@ function startTests(chai, proj4, testPoints) {
           319180,
           6399862,
           0,
-          1000
+          1000,
         ]);
         assert.closeTo(rslt[0], 1271137.9275601401, 0.000001);
         assert.closeTo(rslt[1], 6404230.291459564, 0.000001);


### PR DESCRIPTION
The fix in #245 as fix for #230 is not working for all cases.
This fix also adds a solution when using an array as coords (with z or z and m value).