### PR TITLE
Add "gstmerc" as a name for the gstmerc projection

### DIFF
--- a/lib/projections/gstmerc.js
+++ b/lib/projections/gstmerc.js
@@ -54,7 +54,7 @@ export function inverse(p) {
   return p;
 }
 
-export var names = ["gstmerg"];
+export var names = ["gstmerg", "gstmerc"];
 export default {
   init: init,
   forward: forward,


### PR DESCRIPTION
I'm pretty sure `gstmerg` is a typo and it should be `gstmerc` instead. I've added `gstmerc` as a name but kept `gstmerg` to preserve backwards compatibility. ✌🏽