### PR TITLE
RFC: Datum transformation accuracy

### DIFF
--- a/lib/Proj.js
+++ b/lib/Proj.js
@@ -25,20 +25,20 @@ function Projection(srsCode,callback) {
     callback(srsCode);
     return;
   }
-  if (json.datumCode && json.datumCode !== 'none') {
-    var datumDef = match(Datum, json.datumCode);
-    if (datumDef) {
-      json.datum_params = datumDef.towgs84 ? datumDef.towgs84.split(',') : null;
-      json.ellps = datumDef.ellipse;
-      json.datumName = datumDef.datumName ? datumDef.datumName : json.datumCode;
-    }
+  var datumDef = json.dataumCode ? match(Datum, json.datumCode) : undefined;
+
+  if (datumDef) {
+    json.datum_params = datumDef.towgs84 ? datumDef.towgs84.split(',') : null;
+    json.ellps = datumDef.ellipse;
+    json.datumName = datumDef.datumName ? datumDef.datumName : json.datumCode;
   }
+
   json.k0 = json.k0 || 1.0;
   json.axis = json.axis || 'enu';
   json.ellps = json.ellps || 'wgs84';
   var sphere_ = dc_sphere(json.a, json.b, json.rf, json.ellps, json.sphere);
   var ecc = dc_eccentricity(sphere_.a, sphere_.b, sphere_.rf, json.R_A);
-  var datumObj = json.datum || datum(json.datumCode, json.datum_params, sphere_.a, sphere_.b, ecc.es, ecc.ep2);
+  var datumObj = json.datum || datum(datumDef, json.datum_params, sphere_.a, sphere_.b, ecc.es, ecc.ep2);
 
   extend(this, json); // transfer everything over from the projection because we don't know what we'll need
   extend(this, ourProj); // transfer all the methods from the projection

--- a/lib/datum.js
+++ b/lib/datum.js
@@ -1,12 +1,12 @@
 import {PJD_3PARAM, PJD_7PARAM, PJD_WGS84, PJD_NODATUM, SEC_TO_RAD} from './constants/values';
 
-function datum(datumCode, datum_params, a, b, es, ep2) {
+function datum(datumDef, datum_params, a, b, es, ep2) {
   var out = {};
 
-  if (datumCode === undefined || datumCode === 'none') {
-    out.datum_type = PJD_NODATUM;
-  } else {
+  if (datumDef !== undefined && datumDef.towgs84) {
     out.datum_type = PJD_WGS84;
+  } else {
+    out.datum_type = PJD_NODATUM;
   }
 
   if (datum_params) {


### PR DESCRIPTION
Currently proj4js differs from proj4 in how it handles unknown datums. When proj4 encounters an unknown datum, no datum transformation occurs. When proj4js encounters an unknown datum, it assumes it is WGS84 and performs a datum transform when possible. This causes a noticeable difference in outputs. The following changes this behavior to match proj4 by only performing datum transforms on known datums that contain a towgs84 parameter. This may or may not be the correct approach, and currently causes 208 test failures. The number of failures here is rather concerning. The few that I have compared against proj4 v 4.9.3 after this change show the outputs to be more inline with what the proj4  produces. If the goal of this project is to match the output of proj4, then then maybe all of the tests should be updated with the proj4 output?