### PR TITLE
Do not fail on null transformedArray

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -5,7 +5,7 @@ var wgs84 = proj('WGS84');
 function transformer(from, to, coords) {
   var transformedArray, out, keys;
   if (Array.isArray(coords)) {
-    transformedArray = transform(from, to, coords);
+    transformedArray = transform(from, to, coords) || {x: NaN, y: NaN};
     if (coords.length > 2) {
       if ((typeof from.name !== 'undefined' && from.name === 'geocent') || (typeof to.name !== 'undefined' && to.name === 'geocent')) {
         if (typeof transformedArray.z === 'number') {


### PR DESCRIPTION
When a `forward` or `inverse` transform fails, it returns `null`. But our core transformer does not handle that.

By setting the `x` and `y` coordinates to `NaN` in such cases, we can successfully handle such conversions, and the consumer still knows that something went wrong by looking at the `x` and `y`.

This also fixes openlayers/openlayers#10267.