### PR TITLE
* add support for Projection Gauss_Kruger

### DIFF
--- a/lib/projections/tmerc.js
+++ b/lib/projections/tmerc.js
@@ -164,7 +164,7 @@ export function inverse(p) {
   return p;
 }
 
-export var names = ["Transverse_Mercator", "Transverse Mercator", "tmerc"];
+export var names = ["Transverse_Mercator", "Transverse Mercator", "Gauss_Kruger", "tmerc"];
 export default {
   init: init,
   forward: forward,


### PR DESCRIPTION
Gauss_Kruger uses the same method like Transverse_Mercator. Add Gauss_Kruger projection alias name to lib/projections/tmerc.js so wkt like this can be support:

PROJCS["CGCS2000_3_Degree_GK_CM_111E",GEOGCS["GCS_China_Geodetic_Coordinate_System_2000",DATUM["D_China_2000",SPHEROID["CGCS2000",6378137.0,298.257222101]],PRIMEM["Greenwich",0.0],UNIT["Degree",0.0174532925199433]],PROJECTION["Gauss_Kruger"],PARAMETER["False_Easting",500000.0],PARAMETER["False_Northing",0.0],PARAMETER["Central_Meridian",111.0],PARAMETER["Scale_Factor",1.0],PARAMETER["Latitude_Of_Origin",0.0],UNIT["Meter",1.0]]