### PR TITLE
omerc: prevent calculating Math.asin outside of the [-1, 1] range.

### DIFF
--- a/lib/projections/omerc.js
+++ b/lib/projections/omerc.js
@@ -37,7 +37,7 @@ export function init() {
     this.el = fl * Math.pow(t0, this.bl);
     gl = 0.5 * (fl - 1 / fl);
     this.gamma0 = Math.asin(Math.sin(this.alpha) / dl);
-    this.long0 = this.longc - Math.asin(gl * Math.tan(this.gamma0)) / this.bl;
+    this.long0 = this.longc - Math.asin(Math.min(Math.max(gl * Math.tan(this.gamma0), -1.0), 1.0)) / this.bl;
 
   }
   else {


### PR DESCRIPTION
Because of floating point precision issues, some CRS definitions might end up causing `Math.asin` to be called with something like `1.000000000001` which results in `NaN`.