### PR TITLE
Change default Transverse Mercator algorithm

### DIFF
--- a/lib/parseCode.js
+++ b/lib/parseCode.js
@@ -8,7 +8,7 @@ function testObj(code){
 function testDef(code){
   return code in defs;
 }
- var codeWords = ['PROJECTEDCRS', 'PROJCRS', 'GEOGCS','GEOCCS','PROJCS','LOCAL_CS', 'GEODCRS', 'GEODETICCRS', 'GEODETICDATUM', 'ENGCRS', 'ENGINEERINGCRS'];
+var codeWords = ['PROJECTEDCRS', 'PROJCRS', 'GEOGCS','GEOCCS','PROJCS','LOCAL_CS', 'GEODCRS', 'GEODETICCRS', 'GEODETICDATUM', 'ENGCRS', 'ENGINEERINGCRS'];
 function testWKT(code){
   return codeWords.some(function (word) {
     return code.indexOf(word) > -1;

--- a/lib/projString.js
+++ b/lib/projString.js
@@ -111,6 +111,9 @@ export default function(defData) {
       if (v.length === 3 && legalAxis.indexOf(v.substr(0, 1)) !== -1 && legalAxis.indexOf(v.substr(1, 1)) !== -1 && legalAxis.indexOf(v.substr(2, 1)) !== -1) {
         self.axis = v;
       }
+    },
+    approx: function() {
+      self.approx = true;
     }
   };
   for (paramName in paramObj) {

--- a/lib/projections/etmerc.js
+++ b/lib/projections/etmerc.js
@@ -1,6 +1,7 @@
 // Heavily based on this etmerc projection implementation
 // https://github.com/mbloch/mapshaper-proj/blob/master/src/projections/etmerc.js
 
+import tmerc from '../projections/tmerc';
 import sinh from '../common/sinh';
 import hypot from '../common/hypot';
 import asinhy from '../common/asinhy';
@@ -10,8 +11,14 @@ import clens_cmplx from '../common/clens_cmplx';
 import adjust_lon from '../common/adjust_lon';
 
 export function init() {
-  if (this.es === undefined || this.es <= 0) {
-    throw new Error('incorrect elliptical usage');
+  if (!this.approx && (isNaN(this.es) || this.es <= 0)) {
+    throw new Error('Incorrect elliptical usage. Try using the +approx option in the proj string, or PROJECTION["Fast_Transverse_Mercator"] in the WKT.');
+  }
+  if (this.approx) {
+    // When '+approx' is set, use tmerc instead
+    tmerc.init.apply(this);
+    this.forward = tmerc.forward;
+    this.inverse = tmerc.inverse;
   }
 
   this.x0 = this.x0 !== undefined ? this.x0 : 0;
@@ -156,7 +163,7 @@ export function inverse(p) {
   return p;
 }
 
-export var names = ["Extended_Transverse_Mercator", "Extended Transverse Mercator", "etmerc"];
+export var names = ["Extended_Transverse_Mercator", "Extended Transverse Mercator", "etmerc", "Transverse_Mercator", "Transverse Mercator", "tmerc"];
 export default {
   init: init,
   forward: forward,

--- a/lib/projections/tmerc.js
+++ b/lib/projections/tmerc.js
@@ -164,7 +164,7 @@ export function inverse(p) {
   return p;
 }
 
-export var names = ["Transverse_Mercator", "Transverse Mercator", "tmerc"];
+export var names = ["Fast_Transverse_Mercator", "Fast Transverse Mercator"];
 export default {
   init: init,
   forward: forward,

--- a/test/test.js
+++ b/test/test.js
@@ -25,15 +25,15 @@ function startTests(chai, proj4, testPoints) {
       var sweref99tm = '+proj=utm +zone=33 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs';
       var rt90 = '+lon_0=15.808277777799999 +lat_0=0.0 +k=1.0 +x_0=1500000.0 +y_0=0.0 +proj=tmerc +ellps=bessel +units=m +towgs84=414.1,41.3,603.1,-0.855,2.141,-7.023,0 +no_defs';
       var rslt = proj4(sweref99tm, rt90).forward([319180, 6399862]);
-      assert.closeTo(rslt[0], 1271137.9275601401, 0.000001);
-      assert.closeTo(rslt[1], 6404230.291459564, 0.000001);
+      assert.closeTo(rslt[0], 1271137.927561178, 0.000001);
+      assert.closeTo(rslt[1], 6404230.291456626, 0.000001);
     });
     it('should work with a proj object', function() {
       var sweref99tm = proj4('+proj=utm +zone=33 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs');
       var rt90 = proj4('+lon_0=15.808277777799999 +lat_0=0.0 +k=1.0 +x_0=1500000.0 +y_0=0.0 +proj=tmerc +ellps=bessel +units=m +towgs84=414.1,41.3,603.1,-0.855,2.141,-7.023,0 +no_defs');
       var rslt = proj4(sweref99tm, rt90).forward([319180, 6399862]);
-      assert.closeTo(rslt[0], 1271137.9275601401, 0.000001);
-      assert.closeTo(rslt[1], 6404230.291459564, 0.000001);
+      assert.closeTo(rslt[0], 1271137.927561178, 0.000001);
+      assert.closeTo(rslt[1], 6404230.291456626, 0.000001);
     });
   });
 
@@ -160,7 +160,7 @@ function startTests(chai, proj4, testPoints) {
               assert.closeTo(xy[0], testPoint.xy[0], xyEPSLN, 'x is close');
               assert.closeTo(xy[1], testPoint.xy[1], xyEPSLN, 'y is close');
             });
-            it('should work 3 element ponit object', function() {
+            it('should work 3 element point object', function() {
               var pt = proj4.toPoint(testPoint.xy);
               var ll = proj4(new proj4.Proj(testPoint.code), proj4.WGS84, pt);
               assert.closeTo(ll.x, testPoint.ll[0], llEPSLN, 'x is close');
@@ -183,8 +183,8 @@ function startTests(chai, proj4, testPoints) {
             return 'correct answer';
           }
         });
-        assert.closeTo(rslt.x, 1271137.9275601401, 0.000001);
-        assert.closeTo(rslt.y, 6404230.291459564, 0.000001);
+        assert.closeTo(rslt.x, 1271137.927561178, 0.000001);
+        assert.closeTo(rslt.y, 6404230.291456626, 0.000001);
         assert.equal(rslt.z, 0);
         assert.equal(rslt.m, 1000);
         assert.equal(rslt.method(), 'correct answer');
@@ -217,8 +217,8 @@ function startTests(chai, proj4, testPoints) {
           0,
           1000,
         ]);
-        assert.closeTo(rslt[0], 1271137.9275601401, 0.000001);
-        assert.closeTo(rslt[1], 6404230.291459564, 0.000001);
+        assert.closeTo(rslt[0], 1271137.927561178, 0.000001);
+        assert.closeTo(rslt[1], 6404230.291456626, 0.000001);
         assert.equal(rslt[2], 0);
         assert.equal(rslt[3], 1000);
       });

--- a/test/testData.js
+++ b/test/testData.js
@@ -67,15 +67,20 @@ var testPoints = [
   {code: 'PROJCS["NAD83(CSRS) / UTM zone 17N",GEOGCS["NAD83(CSRS)",DATUM["D_North_American_1983_CSRS98",SPHEROID["GRS_1980",6378137,298.257222101]],PRIMEM["Greenwich",0],UNIT["Degree",0.017453292519943295]],PROJECTION["Transverse_Mercator"],PARAMETER["latitude_of_origin",0],PARAMETER["central_meridian",-81],PARAMETER["scale_factor",0.9996],PARAMETER["false_easting",500000],PARAMETER["false_northing",0],UNIT["Meter",1]]',
     xy: [411461.807497, 4700123.744402],
     ll: [-82.07666015625, 42.448388671875]
-  },{code: 'PROJCS["NAD83(CSRS) / UTM zone 17N",GEOGCS["NAD83(CSRS)",DATUM["NAD83_Canadian_Spatial_Reference_System",SPHEROID["GRS 1980",6378137,298.257222101,AUTHORITY["EPSG","7019"]],AUTHORITY["EPSG","6140"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.01745329251994328,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4617"]],UNIT["metre",1,AUTHORITY["EPSG","9001"]],PROJECTION["Transverse_Mercator"],PARAMETER["latitude_of_origin",0],PARAMETER["central_meridian",-81],PARAMETER["scale_factor",0.9996],PARAMETER["false_easting",500000],PARAMETER["false_northing",0],AUTHORITY["EPSG","2958"],AXIS["Easting",EAST],AXIS["Northing",NORTH]]',
+  },
+  {code: 'PROJCS["NAD83(CSRS) / UTM zone 17N",GEOGCS["NAD83(CSRS)",DATUM["NAD83_Canadian_Spatial_Reference_System",SPHEROID["GRS 1980",6378137,298.257222101,AUTHORITY["EPSG","7019"]],AUTHORITY["EPSG","6140"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.01745329251994328,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4617"]],UNIT["metre",1,AUTHORITY["EPSG","9001"]],PROJECTION["Transverse_Mercator"],PARAMETER["latitude_of_origin",0],PARAMETER["central_meridian",-81],PARAMETER["scale_factor",0.9996],PARAMETER["false_easting",500000],PARAMETER["false_northing",0],AUTHORITY["EPSG","2958"],AXIS["Easting",EAST],AXIS["Northing",NORTH]]',
     xy: [411461.807497, 4700123.744402],
     ll: [-82.07666015625, 42.448388671875]
+  },
+  {code: 'PROJCS["ETRS89 / UTM zone 32N",GEOGCS["ETRS89",DATUM["European_Terrestrial_Reference_System_1989",SPHEROID["GRS 1980",6378137,298.257222101,AUTHORITY["EPSG","7019"]],TOWGS84[0,0,0,0,0,0,0],AUTHORITY["EPSG","6258"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4258"]],PROJECTION["Transverse_Mercator"],PARAMETER["latitude_of_origin",0],PARAMETER["central_meridian",9],PARAMETER["scale_factor",0.9996],PARAMETER["false_easting",500000],PARAMETER["false_northing",0],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["Easting",EAST],AXIS["Northing",NORTH],AUTHORITY["EPSG","25832"]]',
+    xy: [-1877994.66, 3932281.56],
+    ll: [-16.10000000237, 32.879999998812]
   },
   {code: 'PROJCS["World_Mollweide",GEOGCS["GCS_WGS_1984",DATUM["WGS_1984",SPHEROID["WGS_1984",6378137,298.257223563]],PRIMEM["Greenwich",0],UNIT["Degree",0.017453292519943295]],PROJECTION["Mollweide"],PARAMETER["False_Easting",0],PARAMETER["False_Northing",0],PARAMETER["Central_Meridian",0],UNIT["Meter",1],AUTHORITY["EPSG","54009"]]',
     xy: [3891383.58309223, 6876758.9933288],
     ll: [60,60]
   },
-   {code: 'PROJCS["World_Mollweide",GEOGCS["GCS_WGS_1984",DATUM["D_WGS_1984",SPHEROID["WGS_1984",6378137,298.257223563]],PRIMEM["Greenwich",0],UNIT["Degree",0.017453292519943295]],PROJECTION["Mollweide"],PARAMETER["False_Easting",0],PARAMETER["False_Northing",0],PARAMETER["Central_Meridian",0],UNIT["Meter",1]]',
+  {code: 'PROJCS["World_Mollweide",GEOGCS["GCS_WGS_1984",DATUM["D_WGS_1984",SPHEROID["WGS_1984",6378137,298.257223563]],PRIMEM["Greenwich",0],UNIT["Degree",0.017453292519943295]],PROJECTION["Mollweide"],PARAMETER["False_Easting",0],PARAMETER["False_Northing",0],PARAMETER["Central_Meridian",0],UNIT["Meter",1]]',
     xy: [3891383.58309223, 6876758.9933288],
     ll: [60,60]
   },
@@ -507,7 +512,7 @@ var testPoints = [
     xy: [222650.79679577847, 110642.2294119271]
   },
   {
-    code: '+proj=tmerc +a=6400000 +lat_1=0.5 +lat_2=2 +n=0.5',
+    code: '+proj=tmerc +approx +a=6400000 +lat_1=0.5 +lat_2=2 +n=0.5',
     ll: [2, 1],
     xy: [223413.46640632232, 111769.14504059685]
   },

--- a/test/testData.js
+++ b/test/testData.js
@@ -76,6 +76,10 @@ var testPoints = [
     xy: [-1877994.66, 3932281.56],
     ll: [-16.10000000237, 32.879999998812]
   },
+  {code: 'PROJCS["NAD27 / UTM zone 14N",GEOGCS["NAD27 Coordinate System",DATUM["D_North American Datum 1927 (NAD27)",SPHEROID["Clarke_1866",6378206.4,294.97869821391]],PRIMEM["Greenwich",0],UNIT["Degree",0.017453292519943295]],PROJECTION["Transverse_Mercator"],PARAMETER["false_easting",500000],PARAMETER["false_northing",0],PARAMETER["latitude_of_origin",0],PARAMETER["central_meridian",-99],PARAMETER["scale_factor",0.9996],UNIT["Meter (m)",1]]',
+    xy: [2026074.9192811155, 12812891.606450122],
+    ll: [51.517955776474096, 61.56941794249017]
+  },
   {code: 'PROJCS["World_Mollweide",GEOGCS["GCS_WGS_1984",DATUM["WGS_1984",SPHEROID["WGS_1984",6378137,298.257223563]],PRIMEM["Greenwich",0],UNIT["Degree",0.017453292519943295]],PROJECTION["Mollweide"],PARAMETER["False_Easting",0],PARAMETER["False_Northing",0],PARAMETER["Central_Meridian",0],UNIT["Meter",1],AUTHORITY["EPSG","54009"]]',
     xy: [3891383.58309223, 6876758.9933288],
     ll: [60,60]


### PR DESCRIPTION
Similar to what OSGeo/PROJ#1234 did, we are changing the default implementation for Transverse Mercator from `tmerc` to `etmerc`. Extended Transverse Mercator will now be used for all calculation, except when `+approx` is present in the proj string or `PROJECTION["Fast_Transverse_Mercator"]` is set in the WKT.

After this change, the results of cs2cs and proj4 are equal for WKT defs that use UTM zones. With proj strings, these transforms have been working correctly because `etmerc` is used for `+proj=utm` already.

Fixes #362 
Fixes #372