### PR TITLE
Fix API-breaking introduction of axis order enforcement

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,21 @@ proj4.defs can also be used to define a named alias:
 proj4.defs('urn:x-ogc:def:crs:EPSG:4326', proj4.defs('EPSG:4326'));
 ```
 
+## Axis order
+
+By default, proj4 uses `[x,y]` axis order for projected (cartesian) coordinate systems and `[x=longitude,y=latitude]` for geographic coordinates. To enforce the axis order of the provided proj or wkt string, use the
+```javascript
+proj4(fromProjection, toProjection).forward(coordinate, enforceAxis);
+proj4(fromProjection, toProjection).inverse(coordinate, enforceAxis);
+```
+signatures with `enforceAxis` set to `true`:
+```javascript
+proj4('+proj=longlat +ellps=WGS84 +datum=WGS84 +units=degrees +axis=neu', firstProjection).forward([41, -71], true);
+// [242075.00535055372, 750123.32090043]
+proj4('+proj=longlat +ellps=WGS84 +datum=WGS84 +units=degrees +axis=neu', firstProjection).inverse([242075.00535055372, 750123.32090043], true);
+//[40.99999999999986, -71]
+//the floating points to answer your question
+```
 
 ## Grid Based Datum Adjustments
 

--- a/lib/core.js
+++ b/lib/core.js
@@ -2,10 +2,10 @@ import proj from './Proj';
 import transform from './transform';
 var wgs84 = proj('WGS84');
 
-function transformer(from, to, coords) {
+function transformer(from, to, coords, enforceAxis) {
   var transformedArray, out, keys;
   if (Array.isArray(coords)) {
-    transformedArray = transform(from, to, coords) || {x: NaN, y: NaN};
+    transformedArray = transform(from, to, coords, enforceAxis) || {x: NaN, y: NaN};
     if (coords.length > 2) {
       if ((typeof from.name !== 'undefined' && from.name === 'geocent') || (typeof to.name !== 'undefined' && to.name === 'geocent')) {
         if (typeof transformedArray.z === 'number') {
@@ -20,7 +20,7 @@ function transformer(from, to, coords) {
       return [transformedArray.x, transformedArray.y];
     }
   } else {
-    out = transform(from, to, coords);
+    out = transform(from, to, coords, enforceAxis);
     keys = Object.keys(coords);
     if (keys.length === 2) {
       return out;
@@ -70,11 +70,11 @@ function proj4(fromProj, toProj, coord) {
     return transformer(fromProj, toProj, coord);
   } else {
     obj = {
-      forward: function (coords) {
-        return transformer(fromProj, toProj, coords);
+      forward: function (coords, enforceAxis) {
+        return transformer(fromProj, toProj, coords, enforceAxis);
       },
-      inverse: function (coords) {
-        return transformer(toProj, fromProj, coords);
+      inverse: function (coords, enforceAxis) {
+        return transformer(toProj, fromProj, coords, enforceAxis);
       }
     };
     if (single) {

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -9,7 +9,7 @@ function checkNotWGS(source, dest) {
   return ((source.datum.datum_type === PJD_3PARAM || source.datum.datum_type === PJD_7PARAM) && dest.datumCode !== 'WGS84') || ((dest.datum.datum_type === PJD_3PARAM || dest.datum.datum_type === PJD_7PARAM) && source.datumCode !== 'WGS84');
 }
 
-export default function transform(source, dest, point) {
+export default function transform(source, dest, point, enforceAxis) {
   var wgs84;
   if (Array.isArray(point)) {
     point = toPoint(point);
@@ -18,11 +18,11 @@ export default function transform(source, dest, point) {
   // Workaround for datum shifts towgs84, if either source or destination projection is not wgs84
   if (source.datum && dest.datum && checkNotWGS(source, dest)) {
     wgs84 = new proj('WGS84');
-    point = transform(source, wgs84, point);
+    point = transform(source, wgs84, point, enforceAxis);
     source = wgs84;
   }
   // DGR, 2010/11/12
-  if (source.axis !== 'enu') {
+  if (enforceAxis && source.axis !== 'enu') {
     point = adjust_axis(source, false, point);
   }
   // Transform source points to long/lat, if they aren't already.
@@ -84,7 +84,7 @@ export default function transform(source, dest, point) {
   }
 
   // DGR, 2010/11/12
-  if (dest.axis !== 'enu') {
+  if (enforceAxis && dest.axis !== 'enu') {
     return adjust_axis(dest, true, point);
   }
 

--- a/test/test.js
+++ b/test/test.js
@@ -237,25 +237,36 @@ function startTests(chai, proj4, testPoints) {
       });
     });
 
-    it('should use correct axis order', function() {
+    it('should use [x,y] axis order', function() {
       var enu = 'PROJCS["NAD83 / Massachusetts Mainland", GEOGCS["NAD83", DATUM["North American Datum 1983", SPHEROID["GRS 1980", 6378137.0, 298.257222101, AUTHORITY["EPSG","7019"]], TOWGS84[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], AUTHORITY["EPSG","6269"]], PRIMEM["Greenwich", 0.0, AUTHORITY["EPSG","8901"]], UNIT["degree", 0.017453292519943295], AXIS["Geodetic longitude", EAST], AXIS["Geodetic latitude", NORTH], AUTHORITY["EPSG","4269"]], PROJECTION["Lambert_Conformal_Conic_2SP", AUTHORITY["EPSG","9802"]], PARAMETER["central_meridian", -71.5], PARAMETER["latitude_of_origin", 41.0], PARAMETER["standard_parallel_1", 42.68333333333334], PARAMETER["false_easting", 200000.0], PARAMETER["false_northing", 750000.0], PARAMETER["scale_factor", 1.0], PARAMETER["standard_parallel_2", 41.71666666666667], UNIT["m", 1.0], AXIS["Easting", EAST], AXIS["Northing", NORTH], AUTHORITY["EPSG","26986"]]';
       var neu = 'PROJCS["NAD83 / Massachusetts Mainland NE", GEOGCS["NAD83", DATUM["North American Datum 1983", SPHEROID["GRS 1980", 6378137.0, 298.257222101, AUTHORITY["EPSG","7019"]], TOWGS84[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], AUTHORITY["EPSG","6269"]], PRIMEM["Greenwich", 0.0, AUTHORITY["EPSG","8901"]], UNIT["degree", 0.017453292519943295], AXIS["Geodetic latitude", NORTH], AXIS["Geodetic longitude", EAST], AUTHORITY["EPSG","4269"]], PROJECTION["Lambert_Conformal_Conic_2SP", AUTHORITY["EPSG","9802"]], PARAMETER["central_meridian", -71.5], PARAMETER["latitude_of_origin", 41.0], PARAMETER["standard_parallel_1", 42.68333333333334], PARAMETER["false_easting", 200000.0], PARAMETER["false_northing", 750000.0], PARAMETER["scale_factor", 1.0], PARAMETER["standard_parallel_2", 41.71666666666667], UNIT["m", 1.0], AXIS["Northing", NORTH], AXIS["Easting", EAST], AUTHORITY["EPSG","26986"]]';
       var rslt = proj4(enu, neu).forward({
         x: 10.2,
         y: 43.4
       });
+      assert.closeTo(rslt.x, 10.2, 0.000001);
+      assert.closeTo(rslt.y, 43.4, 0.000001);
+    });
+
+    it('should use correct axis order with proj4.transform()', function() {
+      var enu = 'PROJCS["NAD83 / Massachusetts Mainland", GEOGCS["NAD83", DATUM["North American Datum 1983", SPHEROID["GRS 1980", 6378137.0, 298.257222101, AUTHORITY["EPSG","7019"]], TOWGS84[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], AUTHORITY["EPSG","6269"]], PRIMEM["Greenwich", 0.0, AUTHORITY["EPSG","8901"]], UNIT["degree", 0.017453292519943295], AXIS["Geodetic longitude", EAST], AXIS["Geodetic latitude", NORTH], AUTHORITY["EPSG","4269"]], PROJECTION["Lambert_Conformal_Conic_2SP", AUTHORITY["EPSG","9802"]], PARAMETER["central_meridian", -71.5], PARAMETER["latitude_of_origin", 41.0], PARAMETER["standard_parallel_1", 42.68333333333334], PARAMETER["false_easting", 200000.0], PARAMETER["false_northing", 750000.0], PARAMETER["scale_factor", 1.0], PARAMETER["standard_parallel_2", 41.71666666666667], UNIT["m", 1.0], AXIS["Easting", EAST], AXIS["Northing", NORTH], AUTHORITY["EPSG","26986"]]';
+      var neu = 'PROJCS["NAD83 / Massachusetts Mainland NE", GEOGCS["NAD83", DATUM["North American Datum 1983", SPHEROID["GRS 1980", 6378137.0, 298.257222101, AUTHORITY["EPSG","7019"]], TOWGS84[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], AUTHORITY["EPSG","6269"]], PRIMEM["Greenwich", 0.0, AUTHORITY["EPSG","8901"]], UNIT["degree", 0.017453292519943295], AXIS["Geodetic latitude", NORTH], AXIS["Geodetic longitude", EAST], AUTHORITY["EPSG","4269"]], PROJECTION["Lambert_Conformal_Conic_2SP", AUTHORITY["EPSG","9802"]], PARAMETER["central_meridian", -71.5], PARAMETER["latitude_of_origin", 41.0], PARAMETER["standard_parallel_1", 42.68333333333334], PARAMETER["false_easting", 200000.0], PARAMETER["false_northing", 750000.0], PARAMETER["scale_factor", 1.0], PARAMETER["standard_parallel_2", 41.71666666666667], UNIT["m", 1.0], AXIS["Northing", NORTH], AXIS["Easting", EAST], AUTHORITY["EPSG","26986"]]';
+      var rslt = proj4(enu, neu).forward({
+        x: 10.2,
+        y: 43.4
+      }, true);
       assert.closeTo(rslt.x, 43.4, 0.000001);
       assert.closeTo(rslt.y, 10.2, 0.000001);
     });
 
-    it('axes should be invertable', function () {
+    it('axes should be invertable with proj4.transform()', function () {
       var enu = '+proj=longlat +axis=enu';
       var esu = '+proj=longlat +axis=esu';
       var wnu = '+proj=longlat +axis=wnu';
-      var result = proj4(enu, esu).forward({x: 40, y: 50});
+      var result = proj4(enu, esu).forward({x: 40, y: 50}, true);
       assert.closeTo(result.x, 40, 0.000001);
       assert.closeTo(result.y, -50, 0.000001);
-      var result = proj4(enu, wnu).forward({x: 40, y: 50});
+      var result = proj4(enu, wnu).forward({x: 40, y: 50}, true);
       assert.closeTo(result.x, -40, 0.000001);
       assert.closeTo(result.y, 50, 0.000001);
     });


### PR DESCRIPTION
Between v2.6.0 and v2.6.1 we switched from always using `[x,y]` axis order to enforcing the axis order defined in the proj or wkt string. This was considered a fix, but I think it should have been considered a breaking change.

I did some research to see what the `proj` project does: they have a `proj` function which uses `[x,y]` axis order, and a `cs2cs` function which enforces the axis order of the CRS.

This pull request suggests changing the default behavior back to what we had before v2.6.1, and introduce a 2nd argument `enforceAxis` to the `forward()` and `inverse()` functions of the object returned by `proj4(fromProjection, toProjection)`. This way, users can easily opt in to enforcing CRS axis order.

Fixes #391.