### PR TITLE
Parse +over param to disable longitude wrapping

### DIFF
--- a/lib/Proj.js
+++ b/lib/Proj.js
@@ -6,6 +6,7 @@ import Datum from './constants/Datum';
 import datum from './datum';
 import match from './match';
 import {getNadgrids} from "./nadgrid";
+import adjust_lon from "./common/adjust_lon";
 
 function Projection(srsCode,callback) {
   if (!(this instanceof Projection)) {
@@ -64,6 +65,10 @@ function Projection(srsCode,callback) {
 
   // init the projection
   this.init();
+
+  this.adjust_lon = function (x) {
+    return adjust_lon(x, this.over);
+  };
 
   // legecy callback from back in the day when it went to spatialreference.org
   callback(null, this);

--- a/lib/common/adjust_lon.js
+++ b/lib/common/adjust_lon.js
@@ -2,6 +2,6 @@
 import {TWO_PI, SPI} from '../constants/values';
 import sign from './sign';
 
-export default function(x) {
-  return (Math.abs(x) <= SPI) ? x : (x - (sign(x) * TWO_PI));
+export default function(x, over) {
+  return (over || Math.abs(x) <= SPI) ? x : (x - (sign(x) * TWO_PI));
 }

--- a/lib/projString.js
+++ b/lib/projString.js
@@ -117,6 +117,9 @@ export default function(defData) {
     },
     approx: function() {
       self.approx = true;
+    },
+    over: function() {
+      self.over = true;
     }
   };
   for (paramName in paramObj) {

--- a/lib/projections/aea.js
+++ b/lib/projections/aea.js
@@ -1,6 +1,5 @@
 import msfnz from '../common/msfnz';
 import qsfnz from '../common/qsfnz';
-import adjust_lon from '../common/adjust_lon';
 import asinz from '../common/asinz';
 import {EPSLN} from '../constants/values';
 
@@ -53,7 +52,7 @@ export function forward(p) {
 
   var qs = qsfnz(this.e3, this.sin_phi, this.cos_phi);
   var rh1 = this.a * Math.sqrt(this.c - this.ns0 * qs) / this.ns0;
-  var theta = this.ns0 * adjust_lon(lon - this.long0);
+  var theta = this.ns0 * this.adjust_lon(lon - this.long0);
   var x = rh1 * Math.sin(theta) + this.x0;
   var y = this.rh - rh1 * Math.cos(theta) + this.y0;
 
@@ -88,7 +87,7 @@ export function inverse(p) {
     lat = this.phi1z(this.e3, qs);
   }
 
-  lon = adjust_lon(theta / this.ns0 + this.long0);
+  lon = this.adjust_lon(theta / this.ns0 + this.long0);
   p.x = lon;
   p.y = lat;
   return p;

--- a/lib/projections/aeqd.js
+++ b/lib/projections/aeqd.js
@@ -1,4 +1,4 @@
-import adjust_lon from '../common/adjust_lon';
+
 import {HALF_PI, EPSLN} from '../constants/values';
 
 import mlfn from '../common/mlfn';
@@ -22,7 +22,7 @@ export function forward(p) {
   var lat = p.y;
   var sinphi = Math.sin(p.y);
   var cosphi = Math.cos(p.y);
-  var dlon = adjust_lon(lon - this.long0);
+  var dlon = this.adjust_lon(lon - this.long0);
   var e0, e1, e2, e3, Mlp, Ml, tanphi, Nl1, Nl, psi, Az, G, H, GH, Hs, c, kp, cos_c, s, s2, s3, s4, s5;
   if (this.sphere) {
     if (Math.abs(this.sin_p12 - 1) <= EPSLN) {
@@ -125,10 +125,10 @@ export function inverse(p) {
       con = Math.abs(this.lat0) - HALF_PI;
       if (Math.abs(con) <= EPSLN) {
         if (this.lat0 >= 0) {
-          lon = adjust_lon(this.long0 + Math.atan2(p.x, - p.y));
+          lon = this.adjust_lon(this.long0 + Math.atan2(p.x, - p.y));
         }
         else {
-          lon = adjust_lon(this.long0 - Math.atan2(-p.x, p.y));
+          lon = this.adjust_lon(this.long0 - Math.atan2(-p.x, p.y));
         }
       }
       else {
@@ -137,9 +137,9 @@ export function inverse(p) {
           //no-op, just keep the lon value as is
         } else {
           var temp = Math.atan2((p.x * sinz * this.cos_p12), (con * rh));
-          lon = adjust_lon(this.long0 + Math.atan2((p.x * sinz * this.cos_p12), (con * rh)));
+          lon = this.adjust_lon(this.long0 + Math.atan2((p.x * sinz * this.cos_p12), (con * rh)));
         }*/
-        lon = adjust_lon(this.long0 + Math.atan2(p.x * sinz, rh * this.cos_p12 * cosz - p.y * this.sin_p12 * sinz));
+        lon = this.adjust_lon(this.long0 + Math.atan2(p.x * sinz, rh * this.cos_p12 * cosz - p.y * this.sin_p12 * sinz));
       }
     }
 
@@ -158,7 +158,7 @@ export function inverse(p) {
       rh = Math.sqrt(p.x * p.x + p.y * p.y);
       M = Mlp - rh;
       lat = imlfn(M / this.a, e0, e1, e2, e3);
-      lon = adjust_lon(this.long0 + Math.atan2(p.x, - 1 * p.y));
+      lon = this.adjust_lon(this.long0 + Math.atan2(p.x, - 1 * p.y));
       p.x = lon;
       p.y = lat;
       return p;
@@ -170,7 +170,7 @@ export function inverse(p) {
       M = rh - Mlp;
 
       lat = imlfn(M / this.a, e0, e1, e2, e3);
-      lon = adjust_lon(this.long0 + Math.atan2(p.x, p.y));
+      lon = this.adjust_lon(this.long0 + Math.atan2(p.x, p.y));
       p.x = lon;
       p.y = lat;
       return p;
@@ -188,7 +188,7 @@ export function inverse(p) {
       Ee = D - A * (1 + A) * Math.pow(D, 3) / 6 - B * (1 + 3 * A) * Math.pow(D, 4) / 24;
       F = 1 - A * Ee * Ee / 2 - D * Ee * Ee * Ee / 6;
       psi = Math.asin(this.sin_p12 * Math.cos(Ee) + this.cos_p12 * Math.sin(Ee) * cosAz);
-      lon = adjust_lon(this.long0 + Math.asin(Math.sin(Az) * Math.sin(Ee) / Math.cos(psi)));
+      lon = this.adjust_lon(this.long0 + Math.asin(Math.sin(Az) * Math.sin(Ee) / Math.cos(psi)));
       sinpsi = Math.sin(psi);
       lat = Math.atan2((sinpsi - this.es * F * this.sin_p12) * Math.tan(psi), sinpsi * (1 - this.es));
       p.x = lon;

--- a/lib/projections/cass.js
+++ b/lib/projections/cass.js
@@ -4,7 +4,7 @@ import e1fn from '../common/e1fn';
 import e2fn from '../common/e2fn';
 import e3fn from '../common/e3fn';
 import gN from '../common/gN';
-import adjust_lon from '../common/adjust_lon';
+
 import adjust_lat from '../common/adjust_lat';
 import imlfn from '../common/imlfn';
 import {HALF_PI, EPSLN} from '../constants/values';
@@ -28,7 +28,7 @@ export function forward(p) {
   var x, y;
   var lam = p.x;
   var phi = p.y;
-  lam = adjust_lon(lam - this.long0);
+  lam = this.adjust_lon(lam - this.long0);
 
   if (this.sphere) {
     x = this.a * Math.asin(Math.cos(phi) * Math.sin(lam));
@@ -93,7 +93,7 @@ export function inverse(p) {
 
   }
 
-  p.x = adjust_lon(lam + this.long0);
+  p.x = this.adjust_lon(lam + this.long0);
   p.y = adjust_lat(phi);
   return p;
 

--- a/lib/projections/cea.js
+++ b/lib/projections/cea.js
@@ -1,4 +1,4 @@
-import adjust_lon from '../common/adjust_lon';
+
 import qsfnz from '../common/qsfnz';
 import msfnz from '../common/msfnz';
 import iqsfnz from '../common/iqsfnz';
@@ -24,7 +24,7 @@ export function forward(p) {
   var x, y;
   /* Forward equations
       -----------------*/
-  var dlon = adjust_lon(lon - this.long0);
+  var dlon = this.adjust_lon(lon - this.long0);
   if (this.sphere) {
     x = this.x0 + this.a * dlon * Math.cos(this.lat_ts);
     y = this.y0 + this.a * Math.sin(lat) / Math.cos(this.lat_ts);
@@ -48,12 +48,12 @@ export function inverse(p) {
   var lon, lat;
 
   if (this.sphere) {
-    lon = adjust_lon(this.long0 + (p.x / this.a) / Math.cos(this.lat_ts));
+    lon = this.adjust_lon(this.long0 + (p.x / this.a) / Math.cos(this.lat_ts));
     lat = Math.asin((p.y / this.a) * Math.cos(this.lat_ts));
   }
   else {
     lat = iqsfnz(this.e, 2 * p.y * this.k0 / this.a);
-    lon = adjust_lon(this.long0 + p.x / (this.a * this.k0));
+    lon = this.adjust_lon(this.long0 + p.x / (this.a * this.k0));
   }
 
   p.x = lon;

--- a/lib/projections/eqc.js
+++ b/lib/projections/eqc.js
@@ -1,4 +1,4 @@
-import adjust_lon from '../common/adjust_lon';
+
 import adjust_lat from '../common/adjust_lat';
 
 export function init() {
@@ -20,7 +20,7 @@ export function forward(p) {
   var lon = p.x;
   var lat = p.y;
 
-  var dlon = adjust_lon(lon - this.long0);
+  var dlon = this.adjust_lon(lon - this.long0);
   var dlat = adjust_lat(lat - this.lat0);
   p.x = this.x0 + (this.a * dlon * this.rc);
   p.y = this.y0 + (this.a * dlat);
@@ -34,7 +34,7 @@ export function inverse(p) {
   var x = p.x;
   var y = p.y;
 
-  p.x = adjust_lon(this.long0 + ((x - this.x0) / (this.a * this.rc)));
+  p.x = this.adjust_lon(this.long0 + ((x - this.x0) / (this.a * this.rc)));
   p.y = adjust_lat(this.lat0 + ((y - this.y0) / (this.a)));
   return p;
 }

--- a/lib/projections/eqdc.js
+++ b/lib/projections/eqdc.js
@@ -4,7 +4,7 @@ import e2fn from '../common/e2fn';
 import e3fn from '../common/e3fn';
 import msfnz from '../common/msfnz';
 import mlfn from '../common/mlfn';
-import adjust_lon from '../common/adjust_lon';
+
 import adjust_lat from '../common/adjust_lat';
 import imlfn from '../common/imlfn';
 import {EPSLN} from '../constants/values';
@@ -63,7 +63,7 @@ export function forward(p) {
     var ml = mlfn(this.e0, this.e1, this.e2, this.e3, lat);
     rh1 = this.a * (this.g - ml);
   }
-  var theta = this.ns * adjust_lon(lon - this.long0);
+  var theta = this.ns * this.adjust_lon(lon - this.long0);
   var x = this.x0 + rh1 * Math.sin(theta);
   var y = this.y0 + this.rh - rh1 * Math.cos(theta);
   p.x = x;
@@ -91,7 +91,7 @@ export function inverse(p) {
   }
 
   if (this.sphere) {
-    lon = adjust_lon(this.long0 + theta / this.ns);
+    lon = this.adjust_lon(this.long0 + theta / this.ns);
     lat = adjust_lat(this.g - rh1 / this.a);
     p.x = lon;
     p.y = lat;
@@ -100,7 +100,7 @@ export function inverse(p) {
   else {
     var ml = this.g - rh1 / this.a;
     lat = imlfn(ml, this.e0, this.e1, this.e2, this.e3);
-    lon = adjust_lon(this.long0 + theta / this.ns);
+    lon = this.adjust_lon(this.long0 + theta / this.ns);
     p.x = lon;
     p.y = lat;
     return p;

--- a/lib/projections/equi.js
+++ b/lib/projections/equi.js
@@ -1,4 +1,4 @@
-import adjust_lon from '../common/adjust_lon';
+
 
 export function init() {
   this.x0 = this.x0 || 0;
@@ -15,7 +15,7 @@ export function forward(p) {
   var lon = p.x;
   var lat = p.y;
 
-  var dlon = adjust_lon(lon - this.long0);
+  var dlon = this.adjust_lon(lon - this.long0);
   var x = this.x0 + this.a * dlon * Math.cos(this.lat0);
   var y = this.y0 + this.a * lat;
 
@@ -34,7 +34,7 @@ export function inverse(p) {
   p.y -= this.y0;
   var lat = p.y / this.a;
 
-  var lon = adjust_lon(this.long0 + p.x / (this.a * Math.cos(this.lat0)));
+  var lon = this.adjust_lon(this.long0 + p.x / (this.a * Math.cos(this.lat0)));
   p.x = lon;
   p.y = lat;
 }

--- a/lib/projections/etmerc.js
+++ b/lib/projections/etmerc.js
@@ -8,7 +8,7 @@ import asinhy from '../common/asinhy';
 import gatg from '../common/gatg';
 import clens from '../common/clens';
 import clens_cmplx from '../common/clens_cmplx';
-import adjust_lon from '../common/adjust_lon';
+
 
 export function init() {
   if (!this.approx && (isNaN(this.es) || this.es <= 0)) {
@@ -88,7 +88,7 @@ export function init() {
 }
 
 export function forward(p) {
-  var Ce = adjust_lon(p.x - this.long0);
+  var Ce = this.adjust_lon(p.x - this.long0);
   var Cn = p.y;
 
   Cn = gatg(this.cbg, Cn);
@@ -149,7 +149,7 @@ export function inverse(p) {
     Cn = Math.atan2(sin_Cn * cos_Ce, hypot(sin_Ce, cos_Ce * cos_Cn));
     Ce = Math.atan2(sin_Ce, cos_Ce * cos_Cn);
 
-    lon = adjust_lon(Ce + this.long0);
+    lon = this.adjust_lon(Ce + this.long0);
     lat = gatg(this.cgb, Cn);
   }
   else {

--- a/lib/projections/gnom.js
+++ b/lib/projections/gnom.js
@@ -1,4 +1,4 @@
-import adjust_lon from '../common/adjust_lon';
+
 import asinz from '../common/asinz';
 import {EPSLN} from '../constants/values';
 
@@ -32,7 +32,7 @@ export function forward(p) {
   var lat = p.y;
   /* Forward equations
       -----------------*/
-  dlon = adjust_lon(lon - this.long0);
+  dlon = this.adjust_lon(lon - this.long0);
 
   sinphi = Math.sin(lat);
   cosphi = Math.cos(lat);
@@ -83,7 +83,7 @@ export function inverse(p) {
 
     lat = asinz(cosc * this.sin_p14 + (p.y * sinc * this.cos_p14) / rh);
     lon = Math.atan2(p.x * sinc, rh * this.cos_p14 * cosc - p.y * this.sin_p14 * sinc);
-    lon = adjust_lon(this.long0 + lon);
+    lon = this.adjust_lon(this.long0 + lon);
   }
   else {
     lat = this.phic0;

--- a/lib/projections/krovak.js
+++ b/lib/projections/krovak.js
@@ -1,4 +1,4 @@
-import adjust_lon from '../common/adjust_lon';
+
 
 export function init() {
   this.a = 6377397.155;
@@ -39,7 +39,7 @@ export function forward(p) {
   var gfi, u, deltav, s, d, eps, ro;
   var lon = p.x;
   var lat = p.y;
-  var delta_lon = adjust_lon(lon - this.long0);
+  var delta_lon = this.this.adjust_lon(lon - this.long0);
   /* Transformation */
   gfi = Math.pow(((1 + this.e * Math.sin(lat)) / (1 - this.e * Math.sin(lat))), (this.alfa * this.e / 2));
   u = 2 * (Math.atan(this.k * Math.pow(Math.tan(lat / 2 + this.s45), this.alfa) / gfi) - this.s45);

--- a/lib/projections/laea.js
+++ b/lib/projections/laea.js
@@ -77,7 +77,7 @@ export function forward(p) {
   var lam = p.x;
   var phi = p.y;
 
-  lam = adjust_lon(lam - this.long0);
+  lam = this.adjust_lon(lam - this.long0);
   if (this.sphere) {
     sinphi = Math.sin(phi);
     cosphi = Math.cos(phi);
@@ -252,7 +252,7 @@ export function inverse(p) {
     phi = authlat(Math.asin(ab), this.apa);
   }
 
-  p.x = adjust_lon(this.long0 + lam);
+  p.x = this.adjust_lon(this.long0 + lam);
   p.y = phi;
   return p;
 }

--- a/lib/projections/lcc.js
+++ b/lib/projections/lcc.js
@@ -1,11 +1,11 @@
 import msfnz from '../common/msfnz';
 import tsfnz from '../common/tsfnz';
 import sign from '../common/sign';
-import adjust_lon from '../common/adjust_lon';
+
 import phi2z from '../common/phi2z';
 import {HALF_PI, EPSLN} from '../constants/values';
 export function init() {
-  
+
   //double lat0;                    /* the reference latitude               */
   //double long0;                   /* the reference longitude              */
   //double lat1;                    /* first standard parallel              */
@@ -14,7 +14,7 @@ export function init() {
   //double r_min;                   /* minor axis                           */
   //double false_east;              /* x offset in meters                   */
   //double false_north;             /* y offset in meters                   */
-  
+
   //the above value can be set with proj4.defs
   //example: proj4.defs("EPSG:2154","+proj=lcc +lat_1=49 +lat_2=44 +lat_0=46.5 +lon_0=3 +x_0=700000 +y_0=6600000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs");
 
@@ -87,7 +87,7 @@ export function forward(p) {
     }
     rh1 = 0;
   }
-  var theta = this.ns * adjust_lon(lon - this.long0);
+  var theta = this.ns * this.adjust_lon(lon - this.long0);
   p.x = this.k0 * (rh1 * Math.sin(theta)) + this.x0;
   p.y = this.k0 * (this.rh - rh1 * Math.cos(theta)) + this.y0;
 
@@ -125,7 +125,7 @@ export function inverse(p) {
   else {
     lat = -HALF_PI;
   }
-  lon = adjust_lon(theta / this.ns + this.long0);
+  lon = this.adjust_lon(theta / this.ns + this.long0);
 
   p.x = lon;
   p.y = lat;

--- a/lib/projections/merc.js
+++ b/lib/projections/merc.js
@@ -51,13 +51,13 @@ export function forward(p) {
   }
   else {
     if (this.sphere) {
-      x = this.x0 + this.a * this.k0 * adjust_lon(lon - this.long0);
+      x = this.x0 + this.a * this.k0 * this.adjust_lon(lon - this.long0);
       y = this.y0 + this.a * this.k0 * Math.log(Math.tan(FORTPI + 0.5 * lat));
     }
     else {
       var sinphi = Math.sin(lat);
       var ts = tsfnz(this.e, lat, sinphi);
-      x = this.x0 + this.a * this.k0 * adjust_lon(lon - this.long0);
+      x = this.x0 + this.a * this.k0 * this.adjust_lon(lon - this.long0);
       y = this.y0 - this.a * this.k0 * Math.log(ts);
     }
     p.x = x;
@@ -84,7 +84,7 @@ export function inverse(p) {
       return null;
     }
   }
-  lon = adjust_lon(this.long0 + x / (this.a * this.k0));
+  lon = this.adjust_lon(this.long0 + x / (this.a * this.k0));
 
   p.x = lon;
   p.y = lat;

--- a/lib/projections/mill.js
+++ b/lib/projections/mill.js
@@ -20,7 +20,7 @@ export function forward(p) {
   var lat = p.y;
   /* Forward equations
       -----------------*/
-  var dlon = adjust_lon(lon - this.long0);
+  var dlon = this.adjust_lon(lon - this.long0);
   var x = this.x0 + this.a * dlon;
   var y = this.y0 + this.a * Math.log(Math.tan((Math.PI / 4) + (lat / 2.5))) * 1.25;
 
@@ -35,7 +35,7 @@ export function inverse(p) {
   p.x -= this.x0;
   p.y -= this.y0;
 
-  var lon = adjust_lon(this.long0 + p.x / this.a);
+  var lon = this.adjust_lon(this.long0 + p.x / this.a);
   var lat = 2.5 * (Math.atan(Math.exp(0.8 * p.y / this.a)) - Math.PI / 4);
 
   p.x = lon;

--- a/lib/projections/moll.js
+++ b/lib/projections/moll.js
@@ -1,4 +1,4 @@
-import adjust_lon from '../common/adjust_lon';
+
 export function init() {}
 import {EPSLN} from '../constants/values';
 /* Mollweide forward equations--mapping lat,long to x,y
@@ -10,7 +10,7 @@ export function forward(p) {
   var lon = p.x;
   var lat = p.y;
 
-  var delta_lon = adjust_lon(lon - this.long0);
+  var delta_lon = this.adjust_lon(lon - this.long0);
   var theta = lat;
   var con = Math.PI * Math.sin(lat);
 
@@ -56,7 +56,7 @@ export function inverse(p) {
     arg = 0.999999999999;
   }
   theta = Math.asin(arg);
-  var lon = adjust_lon(this.long0 + (p.x / (0.900316316158 * this.a * Math.cos(theta))));
+  var lon = this.adjust_lon(this.long0 + (p.x / (0.900316316158 * this.a * Math.cos(theta))));
   if (lon < (-Math.PI)) {
     lon = -Math.PI;
   }

--- a/lib/projections/omerc.js
+++ b/lib/projections/omerc.js
@@ -8,22 +8,22 @@ var TOL = 1e-7;
 function isTypeA(P) {
   var typeAProjections = ['Hotine_Oblique_Mercator','Hotine_Oblique_Mercator_Azimuth_Natural_Origin'];
   var projectionName = typeof P.PROJECTION === "object" ? Object.keys(P.PROJECTION)[0] : P.PROJECTION;
-  
+
   return 'no_uoff' in P || 'no_off' in P || typeAProjections.indexOf(projectionName) !== -1;
 }
 
 
 /* Initialize the Oblique Mercator  projection
     ------------------------------------------*/
-export function init() {  
+export function init() {
   var con, com, cosph0, D, F, H, L, sinph0, p, J, gamma = 0,
     gamma0, lamc = 0, lam1 = 0, lam2 = 0, phi1 = 0, phi2 = 0, alpha_c = 0, AB;
-  
+
   // only Type A uses the no_off or no_uoff property
   // https://github.com/OSGeo/proj.4/issues/104
   this.no_off = isTypeA(this);
   this.no_rot = 'no_rot' in this;
-  
+
   var alp = false;
   if ("alpha" in this) {
     alp = true;
@@ -37,11 +37,11 @@ export function init() {
   if (alp) {
     alpha_c = this.alpha;
   }
-  
+
   if (gam) {
     gamma = (this.rectified_grid_angle * D2R);
   }
-  
+
   if (alp || gam) {
     lamc = this.longc;
   } else {
@@ -49,17 +49,17 @@ export function init() {
     phi1 = this.lat1;
     lam2 = this.long2;
     phi2 = this.lat2;
-    
+
     if (Math.abs(phi1 - phi2) <= TOL || (con = Math.abs(phi1)) <= TOL ||
         Math.abs(con - HALF_PI) <= TOL || Math.abs(Math.abs(this.lat0) - HALF_PI) <= TOL ||
         Math.abs(Math.abs(phi2) - HALF_PI) <= TOL) {
       throw new Error();
     }
   }
-  
+
   var one_es = 1.0 - this.es;
   com = Math.sqrt(one_es);
-  
+
   if (Math.abs(this.lat0) > EPSLN) {
     sinph0 = Math.sin(this.lat0);
     cosph0 = Math.cos(this.lat0);
@@ -69,7 +69,7 @@ export function init() {
     this.A = this.B * this.k0 * com / con;
     D = this.B * com / (cosph0 * Math.sqrt(con));
     F = D * D -1;
-    
+
     if (F <= 0) {
       F = 0;
     } else {
@@ -78,7 +78,7 @@ export function init() {
         F = -F;
       }
     }
-    
+
     this.E = F += D;
     this.E *= Math.pow(tsfnz(this.e, this.lat0, sinph0), this.B);
   } else {
@@ -86,7 +86,7 @@ export function init() {
     this.A = this.k0;
     this.E = D = F = 1;
   }
-  
+
   if (alp || gam) {
     if (alp) {
       gamma0 = Math.asin(Math.sin(alpha_c) / D);
@@ -106,38 +106,38 @@ export function init() {
     J = this.E * this.E;
     J = (J - L * H) / (J + L * H);
     con = lam1 - lam2;
-    
+
     if (con < -Math.pi) {
       lam2 -=TWO_PI;
     } else if (con > Math.pi) {
       lam2 += TWO_PI;
     }
-    
-    this.lam0 = adjust_lon(0.5 * (lam1 + lam2) - Math.atan(J * Math.tan(0.5 * this.B * (lam1 - lam2)) / p) / this.B);
-    gamma0 = Math.atan(2 * Math.sin(this.B * adjust_lon(lam1 - this.lam0)) / (F - 1 / F));
+
+    this.lam0 = this.adjust_lon(0.5 * (lam1 + lam2) - Math.atan(J * Math.tan(0.5 * this.B * (lam1 - lam2)) / p) / this.B);
+    gamma0 = Math.atan(2 * Math.sin(this.B * this.adjust_lon(lam1 - this.lam0)) / (F - 1 / F));
     gamma = alpha_c = Math.asin(D * Math.sin(gamma0));
   }
-  
+
   this.singam = Math.sin(gamma0);
   this.cosgam = Math.cos(gamma0);
   this.sinrot = Math.sin(gamma);
   this.cosrot = Math.cos(gamma);
-  
+
   this.rB = 1 / this.B;
   this.ArB = this.A * this.rB;
   this.BrA = 1 / this.ArB;
   AB = this.A * this.B;
-  
+
   if (this.no_off) {
     this.u_0 = 0;
   } else {
     this.u_0 = Math.abs(this.ArB * Math.atan(Math.sqrt(D * D - 1) / Math.cos(alpha_c)));
-    
+
     if (this.lat0 < 0) {
       this.u_0 = - this.u_0;
-    }  
+    }
   }
-    
+
   F = 0.5 * gamma0;
   this.v_pole_n = this.ArB * Math.log(Math.tan(FORTPI - F));
   this.v_pole_s = this.ArB * Math.log(Math.tan(FORTPI + F));
@@ -150,33 +150,33 @@ export function forward(p) {
   var coords = {};
   var S, T, U, V, W, temp, u, v;
   p.x = p.x - this.lam0;
-  
+
   if (Math.abs(Math.abs(p.y) - HALF_PI) > EPSLN) {
     W = this.E / Math.pow(tsfnz(this.e, p.y, Math.sin(p.y)), this.B);
-    
+
     temp = 1 / W;
     S = 0.5 * (W - temp);
     T = 0.5 * (W + temp);
     V = Math.sin(this.B * p.x);
     U = (S * this.singam - V * this.cosgam) / T;
-        
+
     if (Math.abs(Math.abs(U) - 1.0) < EPSLN) {
       throw new Error();
     }
-    
+
     v = 0.5 * this.ArB * Math.log((1 - U)/(1 + U));
     temp = Math.cos(this.B * p.x);
-    
+
     if (Math.abs(temp) < TOL) {
       u = this.A * p.x;
     } else {
       u = this.ArB * Math.atan2((S * this.cosgam + V * this.singam), temp);
-    }    
+    }
   } else {
     v = p.y > 0 ? this.v_pole_n : this.v_pole_s;
     u = this.ArB * p.y;
   }
-     
+
   if (this.no_rot) {
     coords.x = u;
     coords.y = v;
@@ -185,17 +185,17 @@ export function forward(p) {
     coords.x = v * this.cosrot + u * this.sinrot;
     coords.y = u * this.cosrot - v * this.sinrot;
   }
-  
+
   coords.x = (this.a * coords.x + this.x0);
   coords.y = (this.a * coords.y + this.y0);
-  
+
   return coords;
 }
 
 export function inverse(p) {
   var u, v, Qp, Sp, Tp, Vp, Up;
   var coords = {};
-  
+
   p.x = (p.x - this.x0) * (1.0 / this.a);
   p.y = (p.y - this.y0) * (1.0 / this.a);
 
@@ -206,29 +206,29 @@ export function inverse(p) {
     v = p.x * this.cosrot - p.y * this.sinrot;
     u = p.y * this.cosrot + p.x * this.sinrot + this.u_0;
   }
-  
+
   Qp = Math.exp(-this.BrA * v);
   Sp = 0.5 * (Qp - 1 / Qp);
   Tp = 0.5 * (Qp + 1 / Qp);
   Vp = Math.sin(this.BrA * u);
   Up = (Vp * this.cosgam + Sp * this.singam) / Tp;
-  
+
   if (Math.abs(Math.abs(Up) - 1) < EPSLN) {
     coords.x = 0;
     coords.y = Up < 0 ? -HALF_PI : HALF_PI;
   } else {
     coords.y = this.E / Math.sqrt((1 + Up) / (1 - Up));
     coords.y = phi2z(this.e, Math.pow(coords.y, 1 / this.B));
-    
+
     if (coords.y === Infinity) {
       throw new Error();
     }
-        
+
     coords.x = -this.rB * Math.atan2((Sp * this.cosgam - Vp * this.singam), Math.cos(this.BrA * u));
   }
-  
+
   coords.x += this.lam0;
-  
+
   return coords;
 }
 

--- a/lib/projections/ortho.js
+++ b/lib/projections/ortho.js
@@ -23,7 +23,7 @@ export function forward(p) {
   var lat = p.y;
   /* Forward equations
       -----------------*/
-  dlon = adjust_lon(lon - this.long0);
+  dlon = this.adjust_lon(lon - this.long0);
 
   sinphi = Math.sin(lat);
   cosphi = Math.cos(lat);
@@ -67,16 +67,16 @@ export function inverse(p) {
   con = Math.abs(this.lat0) - HALF_PI;
   if (Math.abs(con) <= EPSLN) {
     if (this.lat0 >= 0) {
-      lon = adjust_lon(this.long0 + Math.atan2(p.x, - p.y));
+      lon = this.adjust_lon(this.long0 + Math.atan2(p.x, - p.y));
     }
     else {
-      lon = adjust_lon(this.long0 - Math.atan2(-p.x, p.y));
+      lon = this.adjust_lon(this.long0 - Math.atan2(-p.x, p.y));
     }
     p.x = lon;
     p.y = lat;
     return p;
   }
-  lon = adjust_lon(this.long0 + Math.atan2((p.x * sinz), rh * this.cos_p14 * cosz - p.y * this.sin_p14 * sinz));
+  lon = this.adjust_lon(this.long0 + Math.atan2((p.x * sinz), rh * this.cos_p14 * cosz - p.y * this.sin_p14 * sinz));
   p.x = lon;
   p.y = lat;
   return p;

--- a/lib/projections/poly.js
+++ b/lib/projections/poly.js
@@ -2,7 +2,7 @@ import e0fn from '../common/e0fn';
 import e1fn from '../common/e1fn';
 import e2fn from '../common/e2fn';
 import e3fn from '../common/e3fn';
-import adjust_lon from '../common/adjust_lon';
+
 import adjust_lat from '../common/adjust_lat';
 import mlfn from '../common/mlfn';
 import {EPSLN} from '../constants/values';
@@ -29,7 +29,7 @@ export function forward(p) {
   var lon = p.x;
   var lat = p.y;
   var x, y, el;
-  var dlon = adjust_lon(lon - this.long0);
+  var dlon = this.adjust_lon(lon - this.long0);
   el = dlon * Math.sin(lat);
   if (this.sphere) {
     if (Math.abs(lat) <= EPSLN) {
@@ -69,7 +69,7 @@ export function inverse(p) {
 
   if (this.sphere) {
     if (Math.abs(y + this.a * this.lat0) <= EPSLN) {
-      lon = adjust_lon(x / this.a + this.long0);
+      lon = this.adjust_lon(x / this.a + this.long0);
       lat = 0;
     }
     else {
@@ -86,13 +86,13 @@ export function inverse(p) {
           break;
         }
       }
-      lon = adjust_lon(this.long0 + (Math.asin(x * Math.tan(phi) / this.a)) / Math.sin(lat));
+      lon = this.adjust_lon(this.long0 + (Math.asin(x * Math.tan(phi) / this.a)) / Math.sin(lat));
     }
   }
   else {
     if (Math.abs(y + this.ml0) <= EPSLN) {
       lat = 0;
-      lon = adjust_lon(this.long0 + x / this.a);
+      lon = this.adjust_lon(this.long0 + x / this.a);
     }
     else {
 
@@ -117,7 +117,7 @@ export function inverse(p) {
 
       //lat=phi4z(this.e,this.e0,this.e1,this.e2,this.e3,al,bl,0,0);
       cl = Math.sqrt(1 - this.es * Math.pow(Math.sin(lat), 2)) * Math.tan(lat);
-      lon = adjust_lon(this.long0 + Math.asin(x * cl / this.a) / Math.sin(lat));
+      lon = this.adjust_lon(this.long0 + Math.asin(x * cl / this.a) / Math.sin(lat));
     }
   }
 

--- a/lib/projections/robin.js
+++ b/lib/projections/robin.js
@@ -84,7 +84,7 @@ export function init() {
 }
 
 export function forward(ll) {
-    var lon = adjust_lon(ll.x - this.long0);
+    var lon = this.adjust_lon(ll.x - this.long0);
 
     var dphi = Math.abs(ll.y);
     var i = Math.floor(dphi * C1);
@@ -148,7 +148,7 @@ export function inverse(xy) {
         }
     }
 
-    ll.x = adjust_lon(ll.x + this.long0);
+    ll.x = this.adjust_lon(ll.x + this.long0);
     return ll;
 }
 

--- a/lib/projections/sinu.js
+++ b/lib/projections/sinu.js
@@ -35,7 +35,7 @@ export function forward(p) {
   var lat = p.y;
   /* Forward equations
     -----------------*/
-  lon = adjust_lon(lon - this.long0);
+  lon = this.adjust_lon(lon - this.long0);
 
   if (this.sphere) {
     if (!this.m) {
@@ -85,7 +85,7 @@ export function inverse(p) {
     else if (this.n !== 1) {
       lat = asinz(Math.sin(lat) / this.n);
     }
-    lon = adjust_lon(lon + this.long0);
+    lon = this.adjust_lon(lon + this.long0);
     lat = adjust_lat(lat);
   }
   else {
@@ -95,7 +95,7 @@ export function inverse(p) {
       s = Math.sin(lat);
       temp = this.long0 + p.x * Math.sqrt(1 - this.es * s * s) / (this.a * Math.cos(lat));
       //temp = this.long0 + p.x / (this.a * Math.cos(lat));
-      lon = adjust_lon(temp);
+      lon = this.adjust_lon(temp);
     }
     else if ((s - EPSLN) < HALF_PI) {
       lon = this.long0;

--- a/lib/projections/stere.js
+++ b/lib/projections/stere.js
@@ -50,7 +50,7 @@ export function forward(p) {
   var sinlat = Math.sin(lat);
   var coslat = Math.cos(lat);
   var A, X, sinX, cosX, ts, rh;
-  var dlon = adjust_lon(lon - this.long0);
+  var dlon = this.adjust_lon(lon - this.long0);
 
   if (Math.abs(Math.abs(lon - this.long0) - Math.PI) <= EPSLN && Math.abs(lat + this.lat0) <= EPSLN) {
     //case of the origine point
@@ -114,14 +114,14 @@ export function inverse(p) {
     lat = Math.asin(Math.cos(c) * this.sinlat0 + p.y * Math.sin(c) * this.coslat0 / rh);
     if (Math.abs(this.coslat0) < EPSLN) {
       if (this.lat0 > 0) {
-        lon = adjust_lon(this.long0 + Math.atan2(p.x, - 1 * p.y));
+        lon = this.adjust_lon(this.long0 + Math.atan2(p.x, - 1 * p.y));
       }
       else {
-        lon = adjust_lon(this.long0 + Math.atan2(p.x, p.y));
+        lon = this.adjust_lon(this.long0 + Math.atan2(p.x, p.y));
       }
     }
     else {
-      lon = adjust_lon(this.long0 + Math.atan2(p.x * Math.sin(c), rh * this.coslat0 * Math.cos(c) - p.y * this.sinlat0 * Math.sin(c)));
+      lon = this.adjust_lon(this.long0 + Math.atan2(p.x * Math.sin(c), rh * this.coslat0 * Math.cos(c) - p.y * this.sinlat0 * Math.sin(c)));
     }
     p.x = lon;
     p.y = lat;
@@ -141,7 +141,7 @@ export function inverse(p) {
       p.y *= this.con;
       ts = rh * this.cons / (2 * this.a * this.k0);
       lat = this.con * phi2z(this.e, ts);
-      lon = this.con * adjust_lon(this.con * this.long0 + Math.atan2(p.x, - 1 * p.y));
+      lon = this.con * this.adjust_lon(this.con * this.long0 + Math.atan2(p.x, - 1 * p.y));
     }
     else {
       ce = 2 * Math.atan(rh * this.cosX0 / (2 * this.a * this.k0 * this.ms1));
@@ -151,7 +151,7 @@ export function inverse(p) {
       }
       else {
         Chi = Math.asin(Math.cos(ce) * this.sinX0 + p.y * Math.sin(ce) * this.cosX0 / rh);
-        lon = adjust_lon(this.long0 + Math.atan2(p.x * Math.sin(ce), rh * this.cosX0 * Math.cos(ce) - p.y * this.sinX0 * Math.sin(ce)));
+        lon = this.adjust_lon(this.long0 + Math.atan2(p.x * Math.sin(ce), rh * this.cosX0 * Math.cos(ce) - p.y * this.sinX0 * Math.sin(ce)));
       }
       lat = -1 * phi2z(this.e, Math.tan(0.5 * (HALF_PI + Chi)));
     }

--- a/lib/projections/sterea.js
+++ b/lib/projections/sterea.js
@@ -16,7 +16,7 @@ export function init() {
 
 export function forward(p) {
   var sinc, cosc, cosl, k;
-  p.x = adjust_lon(p.x - this.long0);
+  p.x = this.adjust_lon(p.x - this.long0);
   gauss.forward.apply(this, [p]);
   sinc = Math.sin(p.y);
   cosc = Math.cos(p.y);
@@ -51,7 +51,7 @@ export function inverse(p) {
   p.x = lon;
   p.y = lat;
   gauss.inverse.apply(this, [p]);
-  p.x = adjust_lon(p.x + this.long0);
+  p.x = this.adjust_lon(p.x + this.long0);
   return p;
 }
 

--- a/lib/projections/tmerc.js
+++ b/lib/projections/tmerc.js
@@ -29,7 +29,7 @@ export function forward(p) {
   var lon = p.x;
   var lat = p.y;
 
-  var delta_lon = adjust_lon(lon - this.long0);
+  var delta_lon = this.adjust_lon(lon - this.long0);
   var con;
   var x, y;
   var sin_phi = Math.sin(lat);
@@ -122,7 +122,7 @@ export function inverse(p) {
       lon = 0;
     }
     else {
-      lon = adjust_lon(Math.atan2(g, h) + this.long0);
+      lon = this.adjust_lon(Math.atan2(g, h) + this.long0);
     }
   }
   else { // ellipsoidal form
@@ -147,7 +147,7 @@ export function inverse(p) {
         ds / 30 * (61 + 90 * t - 252 * c * t + 45 * ts + 46 * c -
         ds / 56 * (1385 + 3633 * t + 4095 * ts + 1574 * ts * t))));
 
-      lon = adjust_lon(this.long0 + (d * (1 -
+      lon = this.adjust_lon(this.long0 + (d * (1 -
         ds / 6 * (1 + 2 * t + c -
         ds / 20 * (5 + 28 * t + 24 * ts + 8 * c * t + 6 * c -
         ds / 42 * (61 + 662 * t + 1320 * ts + 720 * ts * t)))) / cos_phi));

--- a/lib/projections/vandg.js
+++ b/lib/projections/vandg.js
@@ -18,7 +18,7 @@ export function forward(p) {
 
   /* Forward equations
     -----------------*/
-  var dlon = adjust_lon(lon - this.long0);
+  var dlon = this.adjust_lon(lon - this.long0);
   var x, y;
 
   if (Math.abs(lat) <= EPSLN) {
@@ -112,7 +112,7 @@ export function inverse(p) {
     lon = this.long0;
   }
   else {
-    lon = adjust_lon(this.long0 + Math.PI * (xys - 1 + Math.sqrt(1 + 2 * (xx * xx - yy * yy) + xys * xys)) / 2 / xx);
+    lon = this.adjust_lon(this.long0 + Math.PI * (xys - 1 + Math.sqrt(1 + 2 * (xx * xx - yy * yy) + xys * xys)) / 2 / xx);
   }
 
   p.x = lon;


### PR DESCRIPTION
Implementation of **over** parameter as described in official [PROJ documentation](https://proj.org/usage/projections.html#cartographic-projection):

`+over` - Allow longitude output outside -180 to 180 range, disables wrapping 


