### PR TITLE
add two name in lcc projections

### DIFF
--- a/lib/projections/lcc.js
+++ b/lib/projections/lcc.js
@@ -139,7 +139,7 @@ export var names = [
   "Lambert_Conformal_Conic_2SP",
   "lcc",
   "Lambert Conic Conformal (1SP)",
-  "Lambert Conic Conformal (2SP)",
+  "Lambert Conic Conformal (2SP)"
 ];
 
 export default {

--- a/lib/projections/lcc.js
+++ b/lib/projections/lcc.js
@@ -137,7 +137,9 @@ export var names = [
   "Lambert_Conformal_Conic",
   "Lambert_Conformal_Conic_1SP",
   "Lambert_Conformal_Conic_2SP",
-  "lcc"
+  "lcc",
+  "Lambert Conic Conformal (1SP)",
+  "Lambert Conic Conformal (2SP)",
 ];
 
 export default {


### PR DESCRIPTION
this two names are missing from lcc names.
"Lambert Conic Conformal (1SP)",
"Lambert Conic Conformal (2SP)",