### PR TITLE
Add 'geos' projection

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -31,7 +31,8 @@ var projs = [
   'qsc',
   'robin',
   'geocent',
-  'tpers'
+  'tpers',
+  'geos'
 ];
 module.exports = function (grunt) {
   grunt.initConfig({

--- a/lib/Proj.js
+++ b/lib/Proj.js
@@ -48,7 +48,7 @@ function Projection(srsCode,callback) {
   extend(this, json); // transfer everything over from the projection because we don't know what we'll need
   extend(this, ourProj); // transfer all the methods from the projection
 
-  // copy the 4 things over we calulated in deriveConstants.sphere
+  // copy the 4 things over we calculated in deriveConstants.sphere
   this.a = sphere_.a;
   this.b = sphere_.b;
   this.rf = sphere_.rf;

--- a/lib/includedProjections.js
+++ b/lib/includedProjections.js
@@ -25,6 +25,7 @@ import qsc from './projections/qsc';
 import robin from './projections/robin';
 import geocent from './projections/geocent';
 import tpers from './projections/tpers';
+import geos from './projections/geos';
 
 var projs = [
   tmerc,
@@ -53,7 +54,8 @@ var projs = [
   qsc,
   robin,
   geocent,
-  tpers
+  tpers,
+  geos,
 ];
 
 export default function (proj4) {

--- a/lib/projections/geos.js
+++ b/lib/projections/geos.js
@@ -1,0 +1,146 @@
+import hypot from '../common/hypot';
+
+export function init() {
+    this.flip_axis = (this.sweep === 'x' ? 1 : 0);
+    this.h = Number(this.h);
+    this.radius_g_1 = this.h / this.a;
+
+    if (this.radius_g_1 <= 0 || this.radius_g_1 > 1e10) {
+        throw new Error();
+    }
+
+    this.radius_g = 1.0 + this.radius_g_1;
+    this.C = this.radius_g * this.radius_g - 1.0;
+
+    if (this.es !== 0.0) {
+        var one_es = 1.0 - this.es;
+        var rone_es = 1 / one_es;
+
+        this.radius_p = Math.sqrt(one_es);
+        this.radius_p2 = one_es;
+        this.radius_p_inv2 = rone_es;
+
+        this.shape = 'ellipse'; // Use as a condition in the forward and inverse functions.
+    } else {
+        this.radius_p = 1.0;
+        this.radius_p2 = 1.0;
+        this.radius_p_inv2 = 1.0;
+
+        this.shape = 'sphere';  // Use as a condition in the forward and inverse functions.
+    }
+
+    if (!this.title) {
+        this.title = "Geostationary Satellite View";
+    }
+}
+
+function forward(p) {
+    var lon = p.x;
+    var lat = p.y;
+    var tmp, v_x, v_y, v_z;
+
+    if (this.shape === 'ellipse') {
+        lat = Math.atan(this.radius_p2 * Math.tan(lat));
+        var r = this.radius_p / hypot(this.radius_p * Math.cos(lat), Math.sin(lat));
+
+        v_x = r * Math.cos(lon) * Math.cos(lat);
+        v_y = r * Math.sin(lon) * Math.cos(lat);
+        v_z = r * Math.sin(lat);
+
+        if (((this.radius_g - v_x) * v_x - v_y * v_y - v_z * v_z * this.radius_p_inv2) < 0.0) {
+            return null;
+        }
+
+        tmp = this.radius_g - v_x;
+        if (this.flip_axis) {
+            p.x = this.radius_g_1 * Math.atan(v_y / hypot(v_z, tmp));
+            p.y = this.radius_g_1 * Math.atan(v_z / tmp);
+        } else {
+            p.x = this.radius_g_1 * Math.atan(v_y / tmp);
+            p.y = this.radius_g_1 * Math.atan(v_z / hypot(v_y, tmp));
+        }
+    } else if (this.shape === 'sphere') {
+        tmp = Math.cos(lat);
+        v_x = Math.cos(lon) * tmp;
+        v_y = Math.sin(lon) * tmp;
+        v_z = Math.sin(lat);
+        tmp = this.radius_g - v_x;
+
+        if (this.flip_axis) {
+            p.x = this.radius_g_1 * Math.atan(v_y / hypot(v_z, tmp));
+            p.y = this.radius_g_1 * Math.atan(v_z / tmp);
+        } else {
+            p.x = this.radius_g_1 * Math.atan(v_y / tmp);
+            p.y = this.radius_g_1 * Math.atan(v_z / hypot(v_y, tmp));
+        }
+    }
+    return p;
+}
+
+function inverse(p) {
+    var v_x = -1.0;
+    var v_y = 0.0;
+    var v_z = 0.0;
+    var a, b, det, k;
+
+    if (this.shape === 'ellipse') {
+        if (this.flip_axis) {
+            v_z = Math.tan(p.y / this.radius_g_1);
+            v_y = Math.tan(p.x / this.radius_g_1) * hypot(1.0, v_z);
+        } else {
+            v_y = Math.tan(p.x / this.radius_g_1);
+            v_z = Math.tan(p.y / this.radius_g_1) * hypot(1.0, v_y);
+        }
+
+        var v_zp = v_z / this.radius_p;
+        a = v_y * v_y + v_zp * v_zp + v_x * v_x;
+        b = 2 * this.radius_g * v_x;
+        det = (b * b) - 4 * a * this.C;
+
+        if (det < 0.0) {
+            return null;
+        }
+
+        k = (-b - Math.sqrt(det)) / (2.0 * a);
+        v_x = this.radius_g + k * v_x;
+        v_y *= k;
+        v_z *= k;
+
+        p.x = Math.atan2(v_y, v_x);
+        p.y = Math.atan(v_z * Math.cos(p.x) / v_x);
+        p.y = Math.atan(this.radius_p_inv2 * Math.tan(p.y));
+    } else if (this.shape === 'sphere') {
+        if (this.flip_axis) {
+            v_z = Math.tan(p.y / this.radius_g_1);
+            v_y = Math.tan(p.x / this.radius_g_1) * Math.sqrt(1.0 + v_z * v_z);
+        } else {
+            v_y = Math.tan(p.x / this.radius_g_1);
+            v_z = Math.tan(p.y / this.radius_g_1) * Math.sqrt(1.0 + v_y * v_y);
+        }
+
+        a = v_y * v_y + v_z * v_z + v_x * v_x;
+        b = 2 * this.radius_g * v_x;
+        det = (b * b) - 4 * a * this.C;
+        if (det < 0.0) {
+            return p;
+        }
+
+        k = (-b - Math.sqrt(det)) / (2.0 * a);
+        v_x = this.radius_g + k * v_x;
+        v_y *= k;
+        v_z *= k;
+
+        p.x = Math.atan2(v_y, v_x);
+        p.y = Math.atan(v_z * Math.cos(p.x) / v_x);
+    }
+    return p;
+}
+
+export var names = ["Geostationary Satellite View", "Geostationary_Satellite", "geos"];
+export default {
+    init: init,
+    forward: forward,
+    inverse: inverse,
+    names: names,
+};
+

--- a/lib/projections/geos.js
+++ b/lib/projections/geos.js
@@ -38,6 +38,7 @@ function forward(p) {
     var lon = p.x;
     var lat = p.y;
     var tmp, v_x, v_y, v_z;
+    lon = lon - this.long0;
 
     if (this.shape === 'ellipse') {
         lat = Math.atan(this.radius_p2 * Math.tan(lat));
@@ -48,7 +49,9 @@ function forward(p) {
         v_z = r * Math.sin(lat);
 
         if (((this.radius_g - v_x) * v_x - v_y * v_y - v_z * v_z * this.radius_p_inv2) < 0.0) {
-            return null;
+            p.x = Number.NaN;
+            p.y = Number.NaN;
+            return p;
         }
 
         tmp = this.radius_g - v_x;
@@ -74,6 +77,8 @@ function forward(p) {
             p.y = this.radius_g_1 * Math.atan(v_z / hypot(v_y, tmp));
         }
     }
+    p.x = p.x * this.a;
+    p.y = p.y * this.a;
     return p;
 }
 
@@ -82,6 +87,9 @@ function inverse(p) {
     var v_y = 0.0;
     var v_z = 0.0;
     var a, b, det, k;
+
+    p.x = p.x / this.a;
+    p.y = p.y / this.a;
 
     if (this.shape === 'ellipse') {
         if (this.flip_axis) {
@@ -98,7 +106,9 @@ function inverse(p) {
         det = (b * b) - 4 * a * this.C;
 
         if (det < 0.0) {
-            return null;
+            p.x = Number.NaN;
+            p.y = Number.NaN;
+            return p;
         }
 
         k = (-b - Math.sqrt(det)) / (2.0 * a);
@@ -122,6 +132,8 @@ function inverse(p) {
         b = 2 * this.radius_g * v_x;
         det = (b * b) - 4 * a * this.C;
         if (det < 0.0) {
+            p.x = Number.NaN;
+            p.y = Number.NaN;
             return p;
         }
 
@@ -133,6 +145,7 @@ function inverse(p) {
         p.x = Math.atan2(v_y, v_x);
         p.y = Math.atan(v_z * Math.cos(p.x) / v_x);
     }
+    p.x = p.x + this.long0;
     return p;
 }
 

--- a/projs.js
+++ b/projs.js
@@ -26,6 +26,7 @@ import qsc from './lib/projections/qsc';
 import robin from './lib/projections/robin';
 import geocent from './lib/projections/geocent';
 import tpers from './lib/projections/tpers';
+import geos from './lib/projections/geos';
 export default function(proj4){
   proj4.Proj.projections.add(tmerc);
   proj4.Proj.projections.add(etmerc);
@@ -55,4 +56,5 @@ export default function(proj4){
   proj4.Proj.projections.add(robin);
   proj4.Proj.projections.add(geocent);
   proj4.Proj.projections.add(tpers);
+  proj4.Proj.projections.add(geos);
 }

--- a/test/testData.js
+++ b/test/testData.js
@@ -807,10 +807,24 @@ var testPoints = [
     code: '+proj=geos +sweep=x +lon_0=-75 +h=35786023 +a=6378137.0 +b=6356752.314',
     ll: [-95, 25],
     xy: [-1920508.77, 2605680.03],
-    // acc: {
-    //   ll: 5,
-    //   xy: 0
-    // }
+  },
+  // Geostationary - Ellipsoid - Y Sweep
+  {
+    code: '+proj=geos +sweep=y +lon_0=-75 +h=35786023 +a=6378137.0 +b=6356752.314',
+    ll: [-95, 25],
+    xy: [-1925601.20, 2601922.01],
+  },
+  // Geostationary - Sphere - X Sweep
+  {
+    code: '+proj=geos +sweep=x +lon_0=-75 +h=35786023 +a=6378137.0 +b=6378137.0',
+    ll: [-95, 25],
+    xy: [-1919131.48, 2621384.15],
+  },
+  // Geostationary - Sphere - Y Sweep
+  {
+    code: '+proj=geos +sweep=y +lon_0=-75 +h=35786023 +a=6378137.0 +b=6378137.0',
+    ll: [-95, 25],
+    xy: [-1924281.93, 2617608.82],
   }
 ];
 if (typeof module !== 'undefined') {

--- a/test/testData.js
+++ b/test/testData.js
@@ -801,6 +801,16 @@ var testPoints = [
       ll: 5,
       xy: 0
     }
+  },
+  // Geostationary - Ellipsoid - X Sweep
+  {
+    code: '+proj=geos +sweep=x +lon_0=-75 +h=35786023 +a=6378137.0 +b=6356752.314',
+    ll: [-95, 25],
+    xy: [-1920508.77, 2605680.03],
+    // acc: {
+    //   ll: 5,
+    //   xy: 0
+    // }
   }
 ];
 if (typeof module !== 'undefined') {


### PR DESCRIPTION
Closes #404

As described in #404, this is an implementation of the 'geos' projection based on the PROJ C library and copied from a custom internal implementation my group was using. The original javascript for the geos projection was hacked into the compiled source for proj4js so I copied it over and did the necessary changes to make it look like the other projection modules here. Keep in mind while reviewing that javascript is not my thing so feel free to comment on style, question why something is done, etc. That said, I'm very familiar with the pyproj library (Python wrapper around PROJ C) and the general concept of projections.

I've only added one test so far and it fails locally so I'm making this PR now to get some further advice. My questions are:

1. What should forward/inverse return when the calculation is invalid? For PROJ/pyproj this would normally return infinity I think. It looks like `merc` uses `null`, but was wondering if the `p` object should have `p.x` and `p.y` set to `null`?
2. Is there an easy way to only run my tests?
3. Is there an easy way to insert a debugger or even show the output of some `console.debug` calls or something and see the output when running the tests? Again, not familiar with common knowledge for JS development.
