### PR TITLE
Bugfix/306 - proj4 modify the input object after a transformation

### DIFF
--- a/lib/transform.js
+++ b/lib/transform.js
@@ -13,6 +13,14 @@ export default function transform(source, dest, point, enforceAxis) {
   var wgs84;
   if (Array.isArray(point)) {
     point = toPoint(point);
+  } else {
+    // Clone the point object so inputs don't get modified
+    point = {
+      x: point.x,
+      y: point.y,
+      z: point.z,
+      m: point.m
+    };
   }
   checkSanity(point);
   // Workaround for datum shifts towgs84, if either source or destination projection is not wgs84

--- a/test/test.js
+++ b/test/test.js
@@ -167,6 +167,15 @@ function startTests(chai, proj4, testPoints) {
               assert.closeTo(ll.y, testPoint.ll[1], llEPSLN, 'y is close');
             });
           });
+          describe('proj coord object', function() {
+            it('should not be modified', function() {
+              var expected = {x: 100000, y: 100000};
+              var inpxy = {x: expected.x, y: expected.y};
+              proj4('EPSG:3857', proj4.WGS84, inpxy);
+
+              assert.deepEqual(inpxy, expected, "input is unmodified");
+            });
+          });
         });
       });
     });


### PR DESCRIPTION
This fixes #306 where a coordinates object passed to `proj4` may be modified (depending on the transform in use).

This PR makes the following changes
- Add test to ensure that the input coordinates are not modified
- Clone the coordinates object in `transform`