### PR TITLE
Use stere instead of sterea for WKT Polar_Stereographic

### DIFF
--- a/lib/projections/stere.js
+++ b/lib/projections/stere.js
@@ -164,7 +164,7 @@ export function inverse(p) {
 
 }
 
-export var names = ["stere", "Stereographic_South_Pole", "Polar Stereographic (variant B)"];
+export var names = ["stere", "Stereographic_South_Pole", "Polar Stereographic (variant B)", "Polar_Stereographic"];
 export default {
   init: init,
   forward: forward,

--- a/lib/projections/sterea.js
+++ b/lib/projections/sterea.js
@@ -55,7 +55,7 @@ export function inverse(p) {
   return p;
 }
 
-export var names = ["Stereographic_North_Pole", "Oblique_Stereographic", "Polar_Stereographic", "sterea","Oblique Stereographic Alternative","Double_Stereographic"];
+export var names = ["Stereographic_North_Pole", "Oblique_Stereographic", "sterea","Oblique Stereographic Alternative","Double_Stereographic"];
 export default {
   init: init,
   forward: forward,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "proj4",
-  "version": "2.8.1-alpha",
+  "version": "2.9.1-alpha",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "proj4",
-      "version": "2.8.1-alpha",
+      "version": "2.9.1-alpha",
       "license": "MIT",
       "dependencies": {
         "mgrs": "1.0.0",
-        "wkt-parser": "^1.3.1"
+        "wkt-parser": "https://github.com/danielschilling-ml/wkt-parser#4158161c0649afbfea905ecf279fc00cec29244b"
       },
       "devDependencies": {
         "chai": "~4.1.2",
@@ -3888,8 +3888,9 @@
     },
     "node_modules/wkt-parser": {
       "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/wkt-parser/-/wkt-parser-1.3.2.tgz",
-      "integrity": "sha512-A26BOOo7sHAagyxG7iuRhnKMO7Q3mEOiOT4oGUmohtN/Li5wameeU4S6f8vWw6NADTVKljBs8bzA8JPQgSEMVQ=="
+      "resolved": "git+ssh://git@github.com/danielschilling-ml/wkt-parser.git#4158161c0649afbfea905ecf279fc00cec29244b",
+      "integrity": "sha512-gygtxAhxFrAURD8bPBvhdSxkVI8Otf6V7pyYNg/nBGmIa7p4dm2QEPiW3lKN5EyFP9Lfu5Ea6ABA/IrcYFifUQ==",
+      "license": "MIT"
     },
     "node_modules/word-wrap": {
       "version": "1.2.3",
@@ -6975,9 +6976,9 @@
       }
     },
     "wkt-parser": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/wkt-parser/-/wkt-parser-1.3.2.tgz",
-      "integrity": "sha512-A26BOOo7sHAagyxG7iuRhnKMO7Q3mEOiOT4oGUmohtN/Li5wameeU4S6f8vWw6NADTVKljBs8bzA8JPQgSEMVQ=="
+      "version": "git+ssh://git@github.com/danielschilling-ml/wkt-parser.git#4158161c0649afbfea905ecf279fc00cec29244b",
+      "integrity": "sha512-gygtxAhxFrAURD8bPBvhdSxkVI8Otf6V7pyYNg/nBGmIa7p4dm2QEPiW3lKN5EyFP9Lfu5Ea6ABA/IrcYFifUQ==",
+      "from": "wkt-parser@https://github.com/danielschilling-ml/wkt-parser#4158161c0649afbfea905ecf279fc00cec29244b"
     },
     "word-wrap": {
       "version": "1.2.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "mgrs": "1.0.0",
-        "wkt-parser": "https://github.com/danielschilling-ml/wkt-parser#4158161c0649afbfea905ecf279fc00cec29244b"
+        "wkt-parser": "^1.3.3"
       },
       "devDependencies": {
         "chai": "~4.1.2",
@@ -3887,10 +3887,9 @@
       }
     },
     "node_modules/wkt-parser": {
-      "version": "1.3.2",
-      "resolved": "git+ssh://git@github.com/danielschilling-ml/wkt-parser.git#4158161c0649afbfea905ecf279fc00cec29244b",
-      "integrity": "sha512-gygtxAhxFrAURD8bPBvhdSxkVI8Otf6V7pyYNg/nBGmIa7p4dm2QEPiW3lKN5EyFP9Lfu5Ea6ABA/IrcYFifUQ==",
-      "license": "MIT"
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/wkt-parser/-/wkt-parser-1.3.3.tgz",
+      "integrity": "sha512-ZnV3yH8/k58ZPACOXeiHaMuXIiaTk1t0hSUVisbO0t4RjA5wPpUytcxeyiN2h+LZRrmuHIh/1UlrR9e7DHDvTw=="
     },
     "node_modules/word-wrap": {
       "version": "1.2.3",
@@ -6976,9 +6975,9 @@
       }
     },
     "wkt-parser": {
-      "version": "git+ssh://git@github.com/danielschilling-ml/wkt-parser.git#4158161c0649afbfea905ecf279fc00cec29244b",
-      "integrity": "sha512-gygtxAhxFrAURD8bPBvhdSxkVI8Otf6V7pyYNg/nBGmIa7p4dm2QEPiW3lKN5EyFP9Lfu5Ea6ABA/IrcYFifUQ==",
-      "from": "wkt-parser@https://github.com/danielschilling-ml/wkt-parser#4158161c0649afbfea905ecf279fc00cec29244b"
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/wkt-parser/-/wkt-parser-1.3.3.tgz",
+      "integrity": "sha512-ZnV3yH8/k58ZPACOXeiHaMuXIiaTk1t0hSUVisbO0t4RjA5wPpUytcxeyiN2h+LZRrmuHIh/1UlrR9e7DHDvTw=="
     },
     "word-wrap": {
       "version": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,6 @@
   },
   "dependencies": {
     "mgrs": "1.0.0",
-    "wkt-parser": "^1.3.1"
+    "wkt-parser": "https://github.com/danielschilling-ml/wkt-parser#4158161c0649afbfea905ecf279fc00cec29244b"
   }
 }

--- a/package.json
+++ b/package.json
@@ -41,6 +41,6 @@
   },
   "dependencies": {
     "mgrs": "1.0.0",
-    "wkt-parser": "https://github.com/danielschilling-ml/wkt-parser#4158161c0649afbfea905ecf279fc00cec29244b"
+    "wkt-parser": "^1.3.3"
   }
 }

--- a/test/testData.js
+++ b/test/testData.js
@@ -824,7 +824,29 @@ var testPoints = [
     code: '+proj=geos +sweep=y +lon_0=-75 +h=35786023 +a=6378137.0 +b=6378137.0',
     ll: [-95, 25],
     xy: [-1924281.93, 2617608.82],
-  }
+  },
+  // WKT - Arctic Polar Stereographic
+  {
+    code: 'PROJCS["WGS 84 / Arctic Polar Stereographic",GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4326"]],PROJECTION["Polar_Stereographic"],PARAMETER["latitude_of_origin",71],PARAMETER["central_meridian",0],PARAMETER["false_easting",0],PARAMETER["false_northing",0],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AUTHORITY["EPSG","3995"]]',
+    ll: [0, 90],
+    xy: [0, 0],
+  },
+  {
+    code: 'PROJCS["WGS 84 / Arctic Polar Stereographic",GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4326"]],PROJECTION["Polar_Stereographic"],PARAMETER["latitude_of_origin",71],PARAMETER["central_meridian",0],PARAMETER["false_easting",0],PARAMETER["false_northing",0],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AUTHORITY["EPSG","3995"]]',
+    ll: [0, 0],
+    xy: [0, -12367396.218459858],
+  },
+  // WKT - Antarctic Polar Stereographic
+  {
+    code: 'PROJCS["WGS 84 / Antarctic Polar Stereographic",GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.01745329251994328,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4326"]],UNIT["metre",1,AUTHORITY["EPSG","9001"]],PROJECTION["Polar_Stereographic"],PARAMETER["latitude_of_origin",-71],PARAMETER["central_meridian",0],PARAMETER["scale_factor",1],PARAMETER["false_easting",0],PARAMETER["false_northing",0],AUTHORITY["EPSG","3031"],AXIS["Easting",UNKNOWN],AXIS["Northing",UNKNOWN]]',
+    ll: [0, -90],
+    xy: [0, 0],
+  },
+  {
+    code: 'PROJCS["WGS 84 / Antarctic Polar Stereographic",GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.01745329251994328,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4326"]],UNIT["metre",1,AUTHORITY["EPSG","9001"]],PROJECTION["Polar_Stereographic"],PARAMETER["latitude_of_origin",-71],PARAMETER["central_meridian",0],PARAMETER["scale_factor",1],PARAMETER["false_easting",0],PARAMETER["false_northing",0],AUTHORITY["EPSG","3031"],AXIS["Easting",UNKNOWN],AXIS["Northing",UNKNOWN]]',
+    ll: [0, 0],
+    xy: [0, 12367396.218459858],
+  },
 ];
 if (typeof module !== 'undefined') {
   module.exports = testPoints;

--- a/test/testData.js
+++ b/test/testData.js
@@ -838,12 +838,12 @@ var testPoints = [
   },
   // WKT - Antarctic Polar Stereographic
   {
-    code: 'PROJCS["WGS 84 / Antarctic Polar Stereographic",GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.01745329251994328,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4326"]],UNIT["metre",1,AUTHORITY["EPSG","9001"]],PROJECTION["Polar_Stereographic"],PARAMETER["latitude_of_origin",-71],PARAMETER["central_meridian",0],PARAMETER["scale_factor",1],PARAMETER["false_easting",0],PARAMETER["false_northing",0],AUTHORITY["EPSG","3031"],AXIS["Easting",UNKNOWN],AXIS["Northing",UNKNOWN]]',
+    code: 'PROJCS["WGS 84 / Antarctic Polar Stereographic",GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.01745329251994328,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4326"]],UNIT["metre",1,AUTHORITY["EPSG","9001"]],PROJECTION["Polar_Stereographic"],PARAMETER["latitude_of_origin",-71],PARAMETER["central_meridian",0],PARAMETER["scale_factor",1],PARAMETER["false_easting",0],PARAMETER["false_northing",0],AUTHORITY["EPSG","3031"]]',
     ll: [0, -90],
     xy: [0, 0],
   },
   {
-    code: 'PROJCS["WGS 84 / Antarctic Polar Stereographic",GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.01745329251994328,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4326"]],UNIT["metre",1,AUTHORITY["EPSG","9001"]],PROJECTION["Polar_Stereographic"],PARAMETER["latitude_of_origin",-71],PARAMETER["central_meridian",0],PARAMETER["scale_factor",1],PARAMETER["false_easting",0],PARAMETER["false_northing",0],AUTHORITY["EPSG","3031"],AXIS["Easting",UNKNOWN],AXIS["Northing",UNKNOWN]]',
+    code: 'PROJCS["WGS 84 / Antarctic Polar Stereographic",GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.01745329251994328,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4326"]],UNIT["metre",1,AUTHORITY["EPSG","9001"]],PROJECTION["Polar_Stereographic"],PARAMETER["latitude_of_origin",-71],PARAMETER["central_meridian",0],PARAMETER["scale_factor",1],PARAMETER["false_easting",0],PARAMETER["false_northing",0],AUTHORITY["EPSG","3031"]]',
     ll: [0, 0],
     xy: [0, 12367396.218459858],
   },


### PR DESCRIPTION
Fixes #433.
Handles WKT Polar_Stereographic strings with stere projection instead of sterea to match proj string behavior.
Adds tests for WKT Polar_Stereographic.
Updates to wkt-parser 1.3.3 for Polar_Stereographic parsing fixes.