### PR TITLE
Added missing default parameters to stere projection

### DIFF
--- a/lib/projections/stere.js
+++ b/lib/projections/stere.js
@@ -12,6 +12,13 @@ export function ssfn_(phit, sinphi, eccen) {
 }
 
 export function init() {
+  
+  // setting default parameters
+  this.x0 = this.x0 || 0;
+  this.y0 = this.y0 || 0;
+  this.lat0 = this.lat0 || 0;
+  this.long0 = this.long0 || 0;
+  
   this.coslat0 = Math.cos(this.lat0);
   this.sinlat0 = Math.sin(this.lat0);
   if (this.sphere) {

--- a/test/testData.js
+++ b/test/testData.js
@@ -287,6 +287,10 @@ var testPoints = [
     ll:[0, -72.5],
     xy:[0, 1045388.79]
   },{
+    code:'+proj=stere',
+    ll:[0, -72.5],
+    xy:[0, -9334375.897187851]
+  },{
     code:'PROJCS["WGS 84 / NSIDC Sea Ice Polar Stereographic South", GEOGCS["WGS 84", DATUM["World Geodetic System 1984", SPHEROID["WGS 84", 6378137.0, 298.257223563, AUTHORITY["EPSG","7030"]], AUTHORITY["EPSG","6326"]], PRIMEM["Greenwich", 0.0, AUTHORITY["EPSG","8901"]], UNIT["degree", 0.017453292519943295], AXIS["Geodetic longitude", EAST], AXIS["Geodetic latitude", NORTH], AUTHORITY["EPSG","4326"]], PROJECTION["Polar Stereographic (variant B)", AUTHORITY["EPSG","9829"]], PARAMETER["central_meridian", 0.0], PARAMETER["Standard_Parallel_1", -70.0], PARAMETER["false_easting", 0.0], PARAMETER["false_northing", 0.0], UNIT["m", 1.0], AXIS["Easting", "North along 90 deg East"], AXIS["Northing", "North along 0 deg"], AUTHORITY["EPSG","3976"]]',
     ll:[0, -72.5],
     xy:[0, 1910008.78441421]


### PR DESCRIPTION
In the [documentation](https://proj.org/operations/projections/stere.html) it is stated that for the the stereographic projection all parameteres are optional.
However, as pointed out in #290, calling the projection with missing x_0, y_0, lat0 or lon0 returns NaN values.
I added the missing default parameters and a new test case.

Fixes #290 