### PR TITLE
Add support for all NTv2 subgrids

### DIFF
--- a/lib/datum_transform.js
+++ b/lib/datum_transform.js
@@ -83,6 +83,7 @@ export function applyGridShift(source, inverse, point) {
   var output = {x: Number.NaN, y: Number.NaN};
   var onlyMandatoryGrids = false;
   var attemptedGrids = [];
+  outer:
   for (var i = 0; i < source.grids.length; i++) {
     var grid = source.grids[i];
     attemptedGrids.push(grid.name);
@@ -98,19 +99,22 @@ export function applyGridShift(source, inverse, point) {
       }
       continue;
     }
-    var subgrid = grid.grid.subgrids[0];
-    // skip tables that don't match our point at all
-    var epsilon = (Math.abs(subgrid.del[1]) + Math.abs(subgrid.del[0])) / 10000.0;
-    var minX = subgrid.ll[0] - epsilon;
-    var minY = subgrid.ll[1] - epsilon;
-    var maxX = subgrid.ll[0] + (subgrid.lim[0] - 1) * subgrid.del[0] + epsilon;
-    var maxY = subgrid.ll[1] + (subgrid.lim[1] - 1) * subgrid.del[1] + epsilon;
-    if (minY > input.y || minX > input.x || maxY < input.y || maxX < input.x ) {
-      continue;
-    }
-    output = applySubgridShift(input, inverse, subgrid);
-    if (!isNaN(output.x)) {
-      break;
+    var subgrids = grid.grid.subgrids;
+    for (var j = 0, jj = subgrids.length; j < jj; j++) {
+      var subgrid = subgrids[j];
+      // skip tables that don't match our point at all
+      var epsilon = (Math.abs(subgrid.del[1]) + Math.abs(subgrid.del[0])) / 10000.0;
+      var minX = subgrid.ll[0] - epsilon;
+      var minY = subgrid.ll[1] - epsilon;
+      var maxX = subgrid.ll[0] + (subgrid.lim[0] - 1) * subgrid.del[0] + epsilon;
+      var maxY = subgrid.ll[1] + (subgrid.lim[1] - 1) * subgrid.del[1] + epsilon;
+      if (minY > input.y || minX > input.x || maxY < input.y || maxX < input.x ) {
+        continue;
+      }
+      output = applySubgridShift(input, inverse, subgrid);
+      if (!isNaN(output.x)) {
+        break outer;
+      }
     }
   }
   if (isNaN(output.x)) {

--- a/lib/nadgrid.js
+++ b/lib/nadgrid.js
@@ -14,9 +14,6 @@ export default function nadgrid(key, data) {
   var view = new DataView(data);
   var isLittleEndian = detectLittleEndian(view);
   var header = readHeader(view, isLittleEndian);
-  if (header.nSubgrids > 1) {
-    console.log('Only single NTv2 subgrids are currently supported, subsequent sub grids are ignored');
-  }
   var subgrids = readSubgrids(view, header, isLittleEndian);
   var nadgrid = {header: header, subgrids: subgrids};
   loadedNadgrids[key] = nadgrid;
@@ -103,6 +100,7 @@ function readSubgrids(view, header, isLittleEndian) {
       count: subHeader.gridNodeCount,
       cvs: mapNodes(nodes)
     });
+    gridOffset += 176 + subHeader.gridNodeCount * 16;
   }
   return grids;
 }


### PR DESCRIPTION
This pull request removes the limitation that all subgrids except for the first one are ignored in NTv2 grid shift files.