### PR TITLE
Define MGI datum

### DIFF
--- a/lib/constants/Datum.js
+++ b/lib/constants/Datum.js
@@ -48,6 +48,12 @@ exports.hermannskogel = {
   datumName: "Hermannskogel"
 };
 
+exports.militargeographische_institut = {
+  towgs84: "577.326,90.129,463.919,5.137,1.474,5.297,2.4232",
+  ellipse: "bessel",
+  datumName: "Militar-Geographische Institut"
+};
+
 exports.osni52 = {
   towgs84: "482.530,-130.596,564.557,-1.042,-0.214,-0.631,8.15",
   ellipse: "airy",


### PR DESCRIPTION
This pull request adds the "Militar-geographische Institut" datum used in Austria.