### PR TITLE
Refine errors and documentation about supported wkt strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ proj4([fromProjection, ]toProjection[, coordinates])
 
 Projections can be proj or wkt strings.
 
+Wkt strings must be in form of [version 1](https://docs.ogc.org/is/18-010r7/18-010r7.html#196) (earlier than 2015). Have a look at the [wkt-parser](https://github.com/proj4js/wkt-parser) for more info, or use proj strings instead.
+
 Coordinates may be an object of the form `{x:x,y:y}` or an array of the form `[x,y]`.
 
 When all 3 arguments  are given, the result is that the coordinates are transformed from projection1 to projection 2. And returned in the same format that they were given in.

--- a/lib/Proj.js
+++ b/lib/Proj.js
@@ -18,12 +18,12 @@ function Projection(srsCode,callback) {
   };
   var json = parseCode(srsCode);
   if(typeof json !== 'object'){
-    callback(srsCode);
+    callback('Could not parse to valid json: ' + srsCode);
     return;
   }
   var ourProj = Projection.projections.get(json.projName);
   if(!ourProj){
-    callback(srsCode);
+    callback('Could not get projection name from: ' + srsCode);
     return;
   }
   if (json.datumCode && json.datumCode !== 'none') {


### PR DESCRIPTION
As discussed in #470, proj4js sometimes throws errors that only contain the wkt string, but not more info about why the error was thrown. This is a bit more refined now.

Addtionally, the readme links to the [wkt-parser](https://github.com/proj4js/wkt-parser) now and mentions that wkt strings have to be provided in the old format.

Closes #470