### PR TITLE
Added named export `proj4` support to index.js

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -19,4 +19,5 @@ proj4.transform = transform;
 proj4.mgrs = mgrs;
 proj4.version = '__VERSION__';
 includedProjections(proj4);
+export { proj4 };
 export default proj4;

--- a/lib/index.js
+++ b/lib/index.js
@@ -19,5 +19,5 @@ proj4.transform = transform;
 proj4.mgrs = mgrs;
 proj4.version = '__VERSION__';
 includedProjections(proj4);
-export { proj4 };
+proj4.default = proj4;
 export default proj4;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "proj4",
-  "version": "2.12.3-alpha",
+  "version": "2.12.2-alpha",
   "description": "Proj4js is a JavaScript library to transform point coordinates from one coordinate system to another, including datum transformations.",
   "homepage": "https://proj4js.github.io/proj4js/",
   "main": "dist/proj4-src.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "proj4",
-  "version": "2.12.2-alpha",
+  "version": "2.12.3-alpha",
   "description": "Proj4js is a JavaScript library to transform point coordinates from one coordinate system to another, including datum transformations.",
   "homepage": "https://proj4js.github.io/proj4js/",
   "main": "dist/proj4-src.js",


### PR DESCRIPTION
Fixes #476 

I hope this can be merged soon, as this issue is actively breaking unit tests in our GIS projects, and additionally is good practice to not have only default exports