### PR TITLE
CompoundCrs: adding the sub crs to defs

### DIFF
--- a/lib/defs.js
+++ b/lib/defs.js
@@ -12,7 +12,14 @@ function defs(name) {
         defs[name] = parseProj(arguments[1]);
       }
       else {
-        defs[name] = wkt(arguments[1]);
+        const proj = wkt(arguments[1]);
+        if (['COMPOUNDCRS', 'COMPD_CS'].includes(proj.type)) {
+          Object.keys(proj).forEach(key => {
+            if (Array.isArray(proj[key]))
+              defs[proj[key].title] = proj[key];
+          })
+        }
+        defs[name] = proj;
       }
     } else {
       defs[name] = def;


### PR DESCRIPTION
Following the PR https://github.com/proj4js/wkt-parser/pull/30.
I suggest in the case of a Compound crs to add all the sub crs to defs. The user then can decide to only use the crs he prefers as Compouds crs in not yet supported by proj4.