### PR TITLE
Fix us-ft and UTM south defs

### DIFF
--- a/lib/constants/units.js
+++ b/lib/constants/units.js
@@ -2,7 +2,7 @@ export default {
   'mm': {to_meter: 0.001},
   'cm': {to_meter: 0.01},
   'ft': {to_meter: 0.3048},
-  'us-ft': {to_meter: 0.304800609601219},
+  'us-ft': {to_meter: 1200 / 3937},
   'fath': {to_meter: 1.8288},
   'kmi': {to_meter: 1852},
   'us-ch': {to_meter: 20.1168402336805},

--- a/lib/global.js
+++ b/lib/global.js
@@ -4,8 +4,8 @@ export default function(defs) {
   defs('EPSG:3857', "+title=WGS 84 / Pseudo-Mercator +proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +no_defs");
   // UTM WGS84
   for (var i = 0; i <= 60; ++i) {
-    defs('EPSG:' + (32600 + i), "+proj=utm +zone=" + i + " +datum=WGS84 +units=m +no_defs");
-    defs('EPSG:' + (32700 + i), "+proj=utm +zone=" + i + " +datum=WGS84 +units=m +no_defs");
+    defs('EPSG:' + (32600 + i), "+proj=utm +zone=" + i + " +datum=WGS84 +units=m");
+    defs('EPSG:' + (32700 + i), "+proj=utm +zone=" + i + " +south +datum=WGS84 +units=m");
   }
 
   defs.WGS84 = defs['EPSG:4326'];


### PR DESCRIPTION
The us-ft units were changed in #480. This pull request changes them back to the more precise previous definitions.

The UTM south codes (EPSG:32701 to EPSG:32760) had an incorrect definition. This fixes them.