### PR TITLE
Fix OSGB1936 datum, add datum lookup by datumName

### DIFF
--- a/lib/constants/Datum.js
+++ b/lib/constants/Datum.js
@@ -1,109 +1,99 @@
-var exports = {};
-export {exports as default};
-exports.wgs84 = {
-  towgs84: "0,0,0",
-  ellipse: "WGS84",
-  datumName: "WGS84"
+var datums = {
+  wgs84: {
+    towgs84: "0,0,0",
+    ellipse: "WGS84",
+    datumName: "WGS84"
+  },
+  ch1903: {
+    towgs84: "674.374,15.056,405.346",
+    ellipse: "bessel",
+    datumName: "swiss"
+  },
+  ggrs87: {
+    towgs84: "-199.87,74.79,246.62",
+    ellipse: "GRS80",
+    datumName: "Greek_Geodetic_Reference_System_1987"
+  },
+  nad83: {
+    towgs84: "0,0,0",
+    ellipse: "GRS80",
+    datumName: "North_American_Datum_1983"
+  },
+  nad27: {
+    nadgrids: "@conus,@alaska,@ntv2_0.gsb,@ntv1_can.dat",
+    ellipse: "clrk66",
+    datumName: "North_American_Datum_1927"
+  },
+  potsdam: {
+    towgs84: "598.1,73.7,418.2,0.202,0.045,-2.455,6.7",
+    ellipse: "bessel",
+    datumName: "Potsdam Rauenberg 1950 DHDN"
+  },
+  carthage: {
+    towgs84: "-263.0,6.0,431.0",
+    ellipse: "clark80",
+    datumName: "Carthage 1934 Tunisia"
+  },
+  hermannskogel: {
+    towgs84: "577.326,90.129,463.919,5.137,1.474,5.297,2.4232",
+    ellipse: "bessel",
+    datumName: "Hermannskogel"
+  },
+  militargeographische_institut: {
+    towgs84: "577.326,90.129,463.919,5.137,1.474,5.297,2.4232",
+    ellipse: "bessel",
+    datumName: "Militar-Geographische Institut",
+  },
+  osni52: {
+    towgs84: "482.530,-130.596,564.557,-1.042,-0.214,-0.631,8.15",
+    ellipse: "airy",
+    datumName: "Irish National"
+  },
+  ire65: {
+    towgs84: "482.530,-130.596,564.557,-1.042,-0.214,-0.631,8.15",
+    ellipse: "mod_airy",
+    datumName: "Ireland 1965"
+  },
+  rassadiran: {
+    towgs84: "-133.63,-157.5,-158.62",
+    ellipse: "intl",
+    datumName: "Rassadiran"
+  },
+  nzgd49: {
+    towgs84: "59.47,-5.04,187.44,0.47,-0.1,1.024,-4.5993",
+    ellipse: "intl",
+    datumName: "New Zealand Geodetic Datum 1949"
+  },
+  osgb36: {
+    towgs84: "446.448,-125.157,542.060,0.1502,0.2470,0.8421,-20.4894",
+    ellipse: "airy",
+    datumName: "Ordnance Survey of Great Britain 1936"
+  },
+  s_jtsk: {
+    towgs84: "589,76,480",
+    ellipse: 'bessel',
+    datumName: 'S-JTSK (Ferro)'
+  },
+  beduaram: {
+    towgs84: '-106,-87,188',
+    ellipse: 'clrk80',
+    datumName: 'Beduaram'
+  },
+  gunung_segara: {
+    towgs84: '-403,684,41',
+    ellipse: 'bessel',
+    datumName: 'Gunung Segara Jakarta'
+  },
+  rnb72: {
+    towgs84: "106.869,-52.2978,103.724,-0.33657,0.456955,-1.84218,1",
+    ellipse: "intl",
+    datumName: "Reseau National Belge 1972"
+  }
 };
 
-exports.ch1903 = {
-  towgs84: "674.374,15.056,405.346",
-  ellipse: "bessel",
-  datumName: "swiss"
-};
+for (var key in datums) {
+  var datum = datums[key];
+  datums[datum.datumName] = datum;
+}
 
-exports.ggrs87 = {
-  towgs84: "-199.87,74.79,246.62",
-  ellipse: "GRS80",
-  datumName: "Greek_Geodetic_Reference_System_1987"
-};
-
-exports.nad83 = {
-  towgs84: "0,0,0",
-  ellipse: "GRS80",
-  datumName: "North_American_Datum_1983"
-};
-
-exports.nad27 = {
-  nadgrids: "@conus,@alaska,@ntv2_0.gsb,@ntv1_can.dat",
-  ellipse: "clrk66",
-  datumName: "North_American_Datum_1927"
-};
-
-exports.potsdam = {
-  towgs84: "598.1,73.7,418.2,0.202,0.045,-2.455,6.7",
-  ellipse: "bessel",
-  datumName: "Potsdam Rauenberg 1950 DHDN"
-};
-
-exports.carthage = {
-  towgs84: "-263.0,6.0,431.0",
-  ellipse: "clark80",
-  datumName: "Carthage 1934 Tunisia"
-};
-
-exports.hermannskogel = {
-  towgs84: "577.326,90.129,463.919,5.137,1.474,5.297,2.4232",
-  ellipse: "bessel",
-  datumName: "Hermannskogel"
-};
-
-exports.militargeographische_institut = {
-  towgs84: "577.326,90.129,463.919,5.137,1.474,5.297,2.4232",
-  ellipse: "bessel",
-  datumName: "Militar-Geographische Institut"
-};
-
-exports.osni52 = {
-  towgs84: "482.530,-130.596,564.557,-1.042,-0.214,-0.631,8.15",
-  ellipse: "airy",
-  datumName: "Irish National"
-};
-
-exports.ire65 = {
-  towgs84: "482.530,-130.596,564.557,-1.042,-0.214,-0.631,8.15",
-  ellipse: "mod_airy",
-  datumName: "Ireland 1965"
-};
-
-exports.rassadiran = {
-  towgs84: "-133.63,-157.5,-158.62",
-  ellipse: "intl",
-  datumName: "Rassadiran"
-};
-
-exports.nzgd49 = {
-  towgs84: "59.47,-5.04,187.44,0.47,-0.1,1.024,-4.5993",
-  ellipse: "intl",
-  datumName: "New Zealand Geodetic Datum 1949"
-};
-
-exports.osgb36 = {
-  towgs84: "446.448,-125.157,542.060,0.1502,0.2470,0.8421,-20.4894",
-  ellipse: "airy",
-  datumName: "Airy 1830"
-};
-
-exports.s_jtsk = {
-  towgs84: "589,76,480",
-  ellipse: 'bessel',
-  datumName: 'S-JTSK (Ferro)'
-};
-
-exports.beduaram = {
-  towgs84: '-106,-87,188',
-  ellipse: 'clrk80',
-  datumName: 'Beduaram'
-};
-
-exports.gunung_segara = {
-  towgs84: '-403,684,41',
-  ellipse: 'bessel',
-  datumName: 'Gunung Segara Jakarta'
-};
-
-exports.rnb72 = {
-  towgs84: "106.869,-52.2978,103.724,-0.33657,0.456955,-1.84218,1",
-  ellipse: "intl",
-  datumName: "Reseau National Belge 1972"
-};
+export default datums;

--- a/test/testData.js
+++ b/test/testData.js
@@ -379,6 +379,11 @@ var testPoints = [
     xy:[325132.0089586496, 674822.638235305]
   },
   {
+    code: 'PROJCS["OSGB36 / British National Grid",GEOGCS["OSGB36",DATUM["Ordnance_Survey_of_Great_Britain_1936",SPHEROID["Airy 1830",6377563.396,299.3249646,AUTHORITY["EPSG","7001"]],AUTHORITY["EPSG","6277"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4277"]],PROJECTION["Transverse_Mercator"],PARAMETER["latitude_of_origin",49],PARAMETER["central_meridian",-2],PARAMETER["scale_factor",0.9996012717],PARAMETER["false_easting",400000],PARAMETER["false_northing",-100000],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["Easting",EAST],AXIS["Northing",NORTH],AUTHORITY["EPSG","27700"]]',
+    ll:[-3.20078, 55.96056],
+    xy:[325132.0089586496, 674822.638235305]
+  },
+  {
     code:"+proj=krovak +lat_0=49.5 +lon_0=24.83333333333333 +alpha=30.28813972222222 +k=0.9999 +x_0=0 +y_0=0 +ellps=bessel +pm=greenwich +units=m +no_defs +towgs84=570.8,85.7,462.8,4.998,1.587,5.261,3.56",
     ll: [12.806988, 49.452262],
     xy: [-868208.61, -1095793.64]


### PR DESCRIPTION
This pull request fixes the name of the OSGB1936 datum, and makes use of the previously unused `datumName` property of the pre-defined datums to make them discoverable also by the name. This makes many WKT definitions work more accurately than before, because the TOWGS84 param can be found now.