### PR TITLE
Support more datum codes with smaller library size

### DIFF
--- a/lib/constants/Datum.js
+++ b/lib/constants/Datum.js
@@ -39,7 +39,7 @@ var datums = {
     ellipse: "bessel",
     datumName: "Hermannskogel"
   },
-  militargeographische_institut: {
+  mgi: {
     towgs84: "577.326,90.129,463.919,5.137,1.474,5.297,2.4232",
     ellipse: "bessel",
     datumName: "Militar-Geographische Institut",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "proj4",
-  "version": "2.13.3-alpha",
+  "version": "2.14.1-alpha",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "proj4",
-      "version": "2.13.3-alpha",
+      "version": "2.14.1-alpha",
       "license": "MIT",
       "dependencies": {
         "mgrs": "1.0.0",
-        "wkt-parser": "^1.3.3"
+        "wkt-parser": "^1.4.0"
       },
       "devDependencies": {
         "chai": "~4.1.2",
@@ -3887,9 +3887,10 @@
       }
     },
     "node_modules/wkt-parser": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/wkt-parser/-/wkt-parser-1.3.3.tgz",
-      "integrity": "sha512-ZnV3yH8/k58ZPACOXeiHaMuXIiaTk1t0hSUVisbO0t4RjA5wPpUytcxeyiN2h+LZRrmuHIh/1UlrR9e7DHDvTw=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/wkt-parser/-/wkt-parser-1.4.0.tgz",
+      "integrity": "sha512-qpwO7Ihds/YYDTi1aADFTI1Sm9YC/tTe3SHD24EeIlZxy7Ik6a1b4HOz7jAi0xdUAw487duqpo8OGu+Tf4nwlQ==",
+      "license": "MIT"
     },
     "node_modules/word-wrap": {
       "version": "1.2.3",
@@ -6975,9 +6976,9 @@
       }
     },
     "wkt-parser": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/wkt-parser/-/wkt-parser-1.3.3.tgz",
-      "integrity": "sha512-ZnV3yH8/k58ZPACOXeiHaMuXIiaTk1t0hSUVisbO0t4RjA5wPpUytcxeyiN2h+LZRrmuHIh/1UlrR9e7DHDvTw=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/wkt-parser/-/wkt-parser-1.4.0.tgz",
+      "integrity": "sha512-qpwO7Ihds/YYDTi1aADFTI1Sm9YC/tTe3SHD24EeIlZxy7Ik6a1b4HOz7jAi0xdUAw487duqpo8OGu+Tf4nwlQ=="
     },
     "word-wrap": {
       "version": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,6 @@
   },
   "dependencies": {
     "mgrs": "1.0.0",
-    "wkt-parser": "^1.3.3"
+    "wkt-parser": "^1.4.0"
   }
 }


### PR DESCRIPTION
Brings in the latest version of wkt-parser, and uses the correct (shorter) datum code for MGI.