### PR TITLE
Add JSDoc types; no longer depend on @types/proj4

### DIFF
--- a/lib/Point.js
+++ b/lib/Point.js
@@ -1,5 +1,11 @@
 import { toPoint, forward } from 'mgrs';
 
+/**
+ * @deprecated v3.0.0 - use proj4.toPoint instead
+ * @param {number | import('./core').TemplateCoordinates | string} x
+ * @param {number} [y]
+ * @param {number} [z]
+ */
 function Point(x, y, z) {
   if (!(this instanceof Point)) {
     return new Point(x, y, z);
@@ -14,9 +20,9 @@ function Point(x, y, z) {
     this.z = x.z || 0.0;
   } else if (typeof x === 'string' && typeof y === 'undefined') {
     var coords = x.split(',');
-    this.x = parseFloat(coords[0], 10);
-    this.y = parseFloat(coords[1], 10);
-    this.z = parseFloat(coords[2], 10) || 0.0;
+    this.x = parseFloat(coords[0]);
+    this.y = parseFloat(coords[1]);
+    this.z = parseFloat(coords[2]) || 0.0;
   } else {
     this.x = x;
     this.y = y;

--- a/lib/Proj.js
+++ b/lib/Proj.js
@@ -7,10 +7,31 @@ import datum from './datum';
 import match from './match';
 import { getNadgrids } from './nadgrid';
 
+/**
+ * @typedef {Object} DatumDefinition
+ * @property {number} datum_type - The type of datum.
+ * @property {number} a - Semi-major axis of the ellipsoid.
+ * @property {number} b - Semi-minor axis of the ellipsoid.
+ * @property {number} es - Eccentricity squared of the ellipsoid.
+ * @property {number} ep2 - Second eccentricity squared of the ellipsoid.
+ */
+
+/**
+ * @param {string | import('./core').PROJJSONDefinition | import('./defs').ProjectionDefinition} srsCode
+ * @param {(errorMessage?: string, instance?: Projection) => void} [callback]
+ */
 function Projection(srsCode, callback) {
   if (!(this instanceof Projection)) {
     return new Projection(srsCode);
   }
+  /** @type {<T extends import('./core').TemplateCoordinates>(coordinates: T, enforceAxis?: boolean) => T} */
+  this.forward = null;
+  /** @type {<T extends import('./core').TemplateCoordinates>(coordinates: T, enforceAxis?: boolean) => T} */
+  this.inverse = null;
+  /** @type {string} */
+  this.name;
+  /** @type {string} */
+  this.title;
   callback = callback || function (error) {
     if (error) {
       throw error;
@@ -42,6 +63,7 @@ function Projection(srsCode, callback) {
   var sphere_ = dc_sphere(json.a, json.b, json.rf, json.ellps, json.sphere);
   var ecc = dc_eccentricity(sphere_.a, sphere_.b, sphere_.rf, json.R_A);
   var nadgrids = getNadgrids(json.nadgrids);
+  /** @type {DatumDefinition} */
   var datumObj = json.datum || datum(json.datumCode, json.datum_params, sphere_.a, sphere_.b, ecc.es, ecc.ep2,
     nadgrids);
 
@@ -63,7 +85,9 @@ function Projection(srsCode, callback) {
   this.datum = datumObj;
 
   // init the projection
-  this.init();
+  if ('init' in this && typeof this.init === 'function') {
+    this.init();
+  }
 
   // legecy callback from back in the day when it went to spatialreference.org
   callback(null, this);

--- a/lib/adjust_axis.js
+++ b/lib/adjust_axis.js
@@ -3,6 +3,7 @@ export default function (crs, denorm, point) {
     yin = point.y,
     zin = point.z || 0.0;
   var v, t, i;
+  /** @type {import("./core").InterfaceCoordinates} */
   var out = {};
   for (i = 0; i < 3; i++) {
     if (denorm && i === 2 && point.z === undefined) {

--- a/lib/common/toPoint.js
+++ b/lib/common/toPoint.js
@@ -1,3 +1,7 @@
+/**
+ * @param {Array<number>} array
+ * @returns {import("../core").InterfaceCoordinates}
+ */
 export default function (array) {
   var out = {
     x: array[0],

--- a/lib/constants/PrimeMeridian.js
+++ b/lib/constants/PrimeMeridian.js
@@ -1,16 +1,17 @@
-var exports = {};
-export { exports as default };
+var primeMeridian = {};
 
-exports.greenwich = 0.0; // "0dE",
-exports.lisbon = -9.131906111111; // "9d07'54.862\"W",
-exports.paris = 2.337229166667; // "2d20'14.025\"E",
-exports.bogota = -74.080916666667; // "74d04'51.3\"W",
-exports.madrid = -3.687938888889; // "3d41'16.58\"W",
-exports.rome = 12.452333333333; // "12d27'8.4\"E",
-exports.bern = 7.439583333333; // "7d26'22.5\"E",
-exports.jakarta = 106.807719444444; // "106d48'27.79\"E",
-exports.ferro = -17.666666666667; // "17d40'W",
-exports.brussels = 4.367975; // "4d22'4.71\"E",
-exports.stockholm = 18.058277777778; // "18d3'29.8\"E",
-exports.athens = 23.7163375; // "23d42'58.815\"E",
-exports.oslo = 10.722916666667; // "10d43'22.5\"E"
+primeMeridian.greenwich = 0.0; // "0dE",
+primeMeridian.lisbon = -9.131906111111; // "9d07'54.862\"W",
+primeMeridian.paris = 2.337229166667; // "2d20'14.025\"E",
+primeMeridian.bogota = -74.080916666667; // "74d04'51.3\"W",
+primeMeridian.madrid = -3.687938888889; // "3d41'16.58\"W",
+primeMeridian.rome = 12.452333333333; // "12d27'8.4\"E",
+primeMeridian.bern = 7.439583333333; // "7d26'22.5\"E",
+primeMeridian.jakarta = 106.807719444444; // "106d48'27.79\"E",
+primeMeridian.ferro = -17.666666666667; // "17d40'W",
+primeMeridian.brussels = 4.367975; // "4d22'4.71\"E",
+primeMeridian.stockholm = 18.058277777778; // "18d3'29.8\"E",
+primeMeridian.athens = 23.7163375; // "23d42'58.815\"E",
+primeMeridian.oslo = 10.722916666667; // "10d43'22.5\"E"
+
+export default primeMeridian;

--- a/lib/core.js
+++ b/lib/core.js
@@ -2,6 +2,85 @@ import proj from './Proj';
 import transform from './transform';
 var wgs84 = proj('WGS84');
 
+/**
+ * @typedef {{x: number, y: number, z?: number, m?: number}} InterfaceCoordinates
+ */
+
+/**
+ * @typedef {Array<number> | InterfaceCoordinates} TemplateCoordinates
+ */
+
+/**
+ * @typedef {Object} Converter
+ * @property {<T extends TemplateCoordinates>(coordinates: T, enforceAxis?: boolean) => T} forward
+ * @property {<T extends TemplateCoordinates>(coordinates: T, enforceAxis?: boolean) => T} inverse
+ * @property {proj} [oProj]
+ */
+
+/**
+ * @typedef {Object} PROJJSONDefinition
+ * @property {string} [$schema]
+ * @property {string} type
+ * @property {string} [name]
+ * @property {{authority: string, code: number}} [id]
+ * @property {string} [scope]
+ * @property {string} [area]
+ * @property {{south_latitude: number, west_longitude: number, north_latitude: number, east_longitude: number}} [bbox]
+ * @property {PROJJSONDefinition[]} [components]
+ * @property {{type: string, name: string}} [datum]
+ * @property {{
+ *   name: string,
+ *   members: Array<{
+ *     name: string,
+ *     id?: {authority: string, code: number}
+ *   }>,
+ *   ellipsoid?: {
+ *     name: string,
+ *     semi_major_axis: number,
+ *     inverse_flattening?: number
+ *   },
+ *   accuracy?: string,
+ *   id?: {authority: string, code: number}
+ * }} [datum_ensemble]
+ * @property {{
+ *   subtype: string,
+ *   axis: Array<{
+ *     name: string,
+ *     abbreviation?: string,
+ *     direction: string,
+ *     unit: string
+ *   }>
+ * }} [coordinate_system]
+ * @property {{
+ *   name: string,
+ *   method: {name: string},
+ *   parameters: Array<{
+ *     name: string,
+ *     value: number,
+ *     unit?: string
+ *   }>
+ * }} [conversion]
+ * @property {{
+ *   name: string,
+ *   method: {name: string},
+ *   parameters: Array<{
+ *     name: string,
+ *     value: number,
+ *     unit?: string,
+ *     type?: string,
+ *     file_name?: string
+ *   }>
+ * }} [transformation]
+ */
+
+/**
+ * @template {TemplateCoordinates} T
+ * @param {proj} from
+ * @param {proj} to
+ * @param {T} coords
+ * @param {boolean} [enforceAxis]
+ * @returns {T}
+ */
 function transformer(from, to, coords, enforceAxis) {
   var transformedArray, out, keys;
   if (Array.isArray(coords)) {
@@ -9,21 +88,21 @@ function transformer(from, to, coords, enforceAxis) {
     if (coords.length > 2) {
       if ((typeof from.name !== 'undefined' && from.name === 'geocent') || (typeof to.name !== 'undefined' && to.name === 'geocent')) {
         if (typeof transformedArray.z === 'number') {
-          return [transformedArray.x, transformedArray.y, transformedArray.z].concat(coords.slice(3));
+          return /** @type {T} */ ([transformedArray.x, transformedArray.y, transformedArray.z].concat(coords.slice(3)));
         } else {
-          return [transformedArray.x, transformedArray.y, coords[2]].concat(coords.slice(3));
+          return /** @type {T} */ ([transformedArray.x, transformedArray.y, coords[2]].concat(coords.slice(3)));
         }
       } else {
-        return [transformedArray.x, transformedArray.y].concat(coords.slice(2));
+        return /** @type {T} */ ([transformedArray.x, transformedArray.y].concat(coords.slice(2)));
       }
     } else {
-      return [transformedArray.x, transformedArray.y];
+      return /** @type {T} */ ([transformedArray.x, transformedArray.y]);
     }
   } else {
     out = transform(from, to, coords, enforceAxis);
     keys = Object.keys(coords);
     if (keys.length === 2) {
-      return out;
+      return /** @type {T} */ (out);
     }
     keys.forEach(function (key) {
       if ((typeof from.name !== 'undefined' && from.name === 'geocent') || (typeof to.name !== 'undefined' && to.name === 'geocent')) {
@@ -37,42 +116,98 @@ function transformer(from, to, coords, enforceAxis) {
       }
       out[key] = coords[key];
     });
-    return out;
+    return /** @type {T} */ (out);
   }
 }
 
+/**
+ * @param {proj | string | PROJJSONDefinition | Converter} item
+ * @returns {import('./Proj').default}
+ */
 function checkProj(item) {
   if (item instanceof proj) {
     return item;
   }
-  if (item.oProj) {
+  if (typeof item === 'object' && 'oProj' in item) {
     return item.oProj;
   }
-  return proj(item);
+  return proj(/** @type {string | PROJJSONDefinition} */ (item));
 }
 
-function proj4(fromProj, toProj, coord) {
-  fromProj = checkProj(fromProj);
+/**
+ * @overload
+ * @param {string | PROJJSONDefinition | proj} toProj
+ * @returns {Converter}
+ */
+/**
+ * @overload
+ * @param {string | PROJJSONDefinition | proj} fromProj
+ * @param {string | PROJJSONDefinition | proj} toProj
+ * @returns {Converter}
+ */
+/**
+ * @overload
+ * @param {string | PROJJSONDefinition | proj} toProj
+ * @param {T} coord
+ * @returns {T}
+ */
+/**
+ * @overload
+ * @param {string | PROJJSONDefinition | proj} fromProj
+ * @param {string | PROJJSONDefinition | proj} toProj
+ * @param {T} coord
+ * @returns {T}
+ */
+/**
+ * @template {TemplateCoordinates} T
+ * @param {string | PROJJSONDefinition | proj} fromProjOrToProj
+ * @param {string | PROJJSONDefinition | proj | TemplateCoordinates} [toProjOrCoord]
+ * @param {T} [coord]
+ * @returns {T|Converter}
+ */
+function proj4(fromProjOrToProj, toProjOrCoord, coord) {
+  /** @type {proj} */
+  var fromProj;
+  /** @type {proj} */
+  var toProj;
   var single = false;
+  /** @type {Converter} */
   var obj;
-  if (typeof toProj === 'undefined') {
-    toProj = fromProj;
+  if (typeof toProjOrCoord === 'undefined') {
+    toProj = checkProj(fromProjOrToProj);
     fromProj = wgs84;
     single = true;
-  } else if (typeof toProj.x !== 'undefined' || Array.isArray(toProj)) {
-    coord = toProj;
-    toProj = fromProj;
+  } else if (typeof /** @type {?} */ (toProjOrCoord).x !== 'undefined' || Array.isArray(toProjOrCoord)) {
+    coord = /** @type {T} */ (/** @type {?} */ (toProjOrCoord));
+    toProj = checkProj(fromProjOrToProj);
     fromProj = wgs84;
     single = true;
   }
-  toProj = checkProj(toProj);
+  if (!fromProj) {
+    fromProj = checkProj(fromProjOrToProj);
+  }
+  if (!toProj) {
+    toProj = checkProj(/** @type {string | PROJJSONDefinition | proj } */ (toProjOrCoord));
+  }
   if (coord) {
     return transformer(fromProj, toProj, coord);
   } else {
     obj = {
+      /**
+       * @template {TemplateCoordinates} T
+       * @param {T} coords
+       * @param {boolean=} enforceAxis
+       * @returns {T}
+       */
       forward: function (coords, enforceAxis) {
         return transformer(fromProj, toProj, coords, enforceAxis);
       },
+      /**
+       * @template {TemplateCoordinates} T
+       * @param {T} coords
+       * @param {boolean=} enforceAxis
+       * @returns {T}
+       */
       inverse: function (coords, enforceAxis) {
         return transformer(toProj, fromProj, coords, enforceAxis);
       }
@@ -83,4 +218,5 @@ function proj4(fromProj, toProj, coord) {
     return obj;
   }
 }
+
 export default proj4;

--- a/lib/defs.js
+++ b/lib/defs.js
@@ -2,6 +2,66 @@ import globals from './global';
 import parseProj from './projString';
 import wkt from 'wkt-parser';
 
+/**
+ * @typedef {Object} ProjectionDefinition
+ * @property {string} title
+ * @property {string} [projName]
+ * @property {string} [ellps]
+ * @property {import('./Proj.js').DatumDefinition} [datum]
+ * @property {string} [datumName]
+ * @property {number} [rf]
+ * @property {number} [lat0]
+ * @property {number} [lat1]
+ * @property {number} [lat2]
+ * @property {number} [lat_ts]
+ * @property {number} [long0]
+ * @property {number} [long1]
+ * @property {number} [long2]
+ * @property {number} [alpha]
+ * @property {number} [longc]
+ * @property {number} [x0]
+ * @property {number} [y0]
+ * @property {number} [k0]
+ * @property {number} [a]
+ * @property {number} [b]
+ * @property {true} [R_A]
+ * @property {number} [zone]
+ * @property {true} [utmSouth]
+ * @property {string|Array<number>} [datum_params]
+ * @property {number} [to_meter]
+ * @property {string} [units]
+ * @property {number} [from_greenwich]
+ * @property {string} [datumCode]
+ * @property {string} [nadgrids]
+ * @property {string} [axis]
+ * @property {boolean} [sphere]
+ * @property {number} [rectified_grid_angle]
+ * @property {boolean} [approx]
+ * @property {<T extends import('./core').TemplateCoordinates>(coordinates: T, enforceAxis?: boolean) => T} inverse
+ * @property {<T extends import('./core').TemplateCoordinates>(coordinates: T, enforceAxis?: boolean) => T} forward
+ */
+
+/**
+ * @overload
+ * @param {string} name
+ * @param {string|ProjectionDefinition|import('./core.js').PROJJSONDefinition} projection
+ * @returns {void}
+ */
+/**
+ * @overload
+ * @param {Array<string, string>} name
+ * @returns {Array<ProjectionDefinition|undefined>}
+ */
+/**
+ * @overload
+ * @param {string} name
+ * @returns {ProjectionDefinition}
+ */
+
+/**
+ * @param {string | Array<Array<string>> | Partial<Record<'EPSG'|'ESRI'|'IAU2000', ProjectionDefinition>>} name
+ * @returns {ProjectionDefinition | Array<ProjectionDefinition|undefined> | void}
+ */
 function defs(name) {
   /* global console */
   var that = this;
@@ -9,20 +69,20 @@ function defs(name) {
     var def = arguments[1];
     if (typeof def === 'string') {
       if (def.charAt(0) === '+') {
-        defs[name] = parseProj(arguments[1]);
+        defs[/** @type {string} */ (name)] = parseProj(arguments[1]);
       } else {
-        defs[name] = wkt(arguments[1]);
+        defs[/** @type {string} */ (name)] = wkt(arguments[1]);
       }
     } else {
-      defs[name] = def;
+      defs[/** @type {string} */ (name)] = def;
     }
   } else if (arguments.length === 1) {
     if (Array.isArray(name)) {
       return name.map(function (v) {
         if (Array.isArray(v)) {
-          defs.apply(that, v);
+          return defs.apply(that, v);
         } else {
-          defs(v);
+          return defs(v);
         }
       });
     } else if (typeof name === 'string') {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,4 @@
-import proj4 from './core';
+import core from './core';
 import Proj from './Proj';
 import Point from './Point';
 import common from './common/toPoint';
@@ -8,15 +8,21 @@ import transform from './transform';
 import mgrs from 'mgrs';
 import includedProjections from '../projs';
 
-proj4.defaultDatum = 'WGS84'; // default datum
-proj4.Proj = Proj;
-proj4.WGS84 = new proj4.Proj('WGS84');
-proj4.Point = Point;
-proj4.toPoint = common;
-proj4.defs = defs;
-proj4.nadgrid = nadgrid;
-proj4.transform = transform;
-proj4.mgrs = mgrs;
-proj4.version = '__VERSION__';
+/**
+ * @template {import('./core').TemplateCoordinates} T
+ * @type {core<T> & {defaultDatum: string, Proj: typeof Proj, WGS84: Proj, Point: typeof Point, toPoint: typeof common, defs: typeof defs, nadgrid: typeof nadgrid, transform: typeof transform, mgrs: typeof mgrs, version: string}}
+ */
+const proj4 = Object.assign(core, {
+  defaultDatum: 'WGS84',
+  Proj,
+  WGS84: new Proj('WGS84'),
+  Point,
+  toPoint: common,
+  defs,
+  nadgrid,
+  transform,
+  mgrs,
+  version: '__VERSION__'
+});
 includedProjections(proj4);
 export default proj4;

--- a/lib/nadgrid.js
+++ b/lib/nadgrid.js
@@ -4,11 +4,64 @@
  * - http://mimaka.com/help/gs/html/004_NTV2%20Data%20Format.htm
  */
 
+/**
+ * @typedef {Object} NadgridInfo
+ * @property {string} name The name of the NAD grid or 'null' if not specified.
+ * @property {boolean} mandatory Indicates if the grid is mandatory (true) or optional (false).
+ * @property {*} grid The loaded NAD grid object, or null if not loaded or not applicable.
+ * @property {boolean} isNull True if the grid is explicitly 'null', otherwise false.
+ */
+
+/**
+ * @typedef {Object} NTV2GridOptions
+ * @property {boolean} [includeErrorFields=true] Whether to include error fields in the subgrids.
+ */
+
+/**
+ * @typedef {Object} NadgridHeader
+ * @property {number} [nFields] Number of fields in the header.
+ * @property {number} [nSubgridFields] Number of fields in each subgrid header.
+ * @property {number} nSubgrids Number of subgrids in the file.
+ * @property {string} [shiftType] Type of shift (e.g., "SECONDS").
+ * @property {number} [fromSemiMajorAxis] Source ellipsoid semi-major axis.
+ * @property {number} [fromSemiMinorAxis] Source ellipsoid semi-minor axis.
+ * @property {number} [toSemiMajorAxis] Target ellipsoid semi-major axis.
+ * @property {number} [toSemiMinorAxis] Target ellipsoid semi-minor axis.
+ */
+
+/**
+ * @typedef {Object} Subgrid
+ * @property {Array<number>} ll Lower left corner of the grid in radians [longitude, latitude].
+ * @property {Array<number>} del Grid spacing in radians [longitude interval, latitude interval].
+ * @property {Array<number>} lim Number of columns in the grid [longitude columns, latitude columns].
+ * @property {number} [count] Total number of grid nodes.
+ * @property {Array} cvs Mapped node values for the grid.
+ */
+
+/** @typedef {{header: NadgridHeader, subgrids: Array<Subgrid>}} NADGrid */
+
 var loadedNadgrids = {};
 
 /**
+ * @overload
+ * @param {string} key - The key to associate with the loaded grid.
+ * @param {ArrayBuffer} data - The NTv2 grid data as an ArrayBuffer.
+ * @param {NTV2GridOptions} [options] - Optional parameters for loading the grid.
+ * @returns {NADGrid} - The loaded NAD grid information.
+ */
+/**
+ * @overload
+ * @param {string} key - The key to associate with the loaded grid.
+ * @param {import('geotiff').GeoTIFF} data - The GeoTIFF instance to read the grid from.
+ * @returns {{ready: Promise<NADGrid>}} - A promise that resolves to the loaded grid information.
+ */
+/**
  * Load either a NTv2 file (.gsb) or a Geotiff (.tif) to a key that can be used in a proj string like +nadgrids=<key>. Pass the NTv2 file
  * as an ArrayBuffer. Pass Geotiff as a GeoTIFF instance from the geotiff.js library.
+ * @param {string} key - The key to associate with the loaded grid.
+ * @param {ArrayBuffer|import('geotiff').GeoTIFF} data The data to load, either an ArrayBuffer for NTv2 or a GeoTIFF instance.
+ * @param {NTV2GridOptions} [options] Optional parameters.
+ * @returns {{ready: Promise<NADGrid>}|NADGrid} - A promise that resolves to the loaded grid information.
  */
 export default function nadgrid(key, data, options) {
   if (data instanceof ArrayBuffer) {
@@ -17,6 +70,12 @@ export default function nadgrid(key, data, options) {
   return { ready: readGeotiffGrid(key, data) };
 }
 
+/**
+ * @param {string} key The key to associate with the loaded grid.
+ * @param {ArrayBuffer} data The NTv2 grid data as an ArrayBuffer.
+ * @param {NTV2GridOptions} [options] Optional parameters for loading the grid.
+ * @returns {NADGrid} The loaded NAD grid information.
+ */
 function readNTV2Grid(key, data, options) {
   var includeErrorFields = true;
   if (options !== undefined && options.includeErrorFields === false) {
@@ -31,6 +90,11 @@ function readNTV2Grid(key, data, options) {
   return nadgrid;
 }
 
+/**
+ * @param {string} key The key to associate with the loaded grid.
+ * @param {import('geotiff').GeoTIFF} tiff The GeoTIFF instance to read the grid from.
+ * @returns {Promise<NADGrid>} A promise that resolves to the loaded NAD grid information.
+ */
 async function readGeotiffGrid(key, tiff) {
   var subgrids = [];
   var subGridCount = await tiff.getImageCount();
@@ -78,6 +142,8 @@ async function readGeotiffGrid(key, tiff) {
 
 /**
  * Given a proj4 value for nadgrids, return an array of loaded grids
+ * @param {string} nadgrids A comma-separated list of grid names, optionally prefixed with '@' to indicate optional grids.
+ * @returns
  */
 export function getNadgrids(nadgrids) {
   // Format details: http://proj.maptools.org/gen_parms.html
@@ -88,6 +154,10 @@ export function getNadgrids(nadgrids) {
   return grids.map(parseNadgridString);
 }
 
+/**
+ * @param {string} value The nadgrid string to get information for.
+ * @returns {NadgridInfo|null} An object with grid information, or null if the input is empty.
+ */
 function parseNadgridString(value) {
   if (value.length === 0) {
     return null;

--- a/lib/parseCode.js
+++ b/lib/parseCode.js
@@ -30,6 +30,10 @@ function checkProjStr(item) {
 function testProj(code) {
   return code[0] === '+';
 }
+/**
+ * @param {string | import('./core').PROJJSONDefinition | import('./defs').ProjectionDefinition} code
+ * @returns {import('./defs').ProjectionDefinition}
+ */
 function parse(code) {
   if (testObj(code)) {
     // check to see if this is a WKT string
@@ -51,7 +55,7 @@ function parse(code) {
     if (testProj(code)) {
       return projStr(code);
     }
-  } else if (!code.projName) {
+  } else if (!('projName' in code)) {
     return wkt(code);
   } else {
     return code;

--- a/lib/projString.js
+++ b/lib/projString.js
@@ -3,13 +3,19 @@ import PrimeMeridian from './constants/PrimeMeridian';
 import units from './constants/units';
 import match from './match';
 
+/**
+ * @param {string} defData
+ * @returns {import('./defs').ProjectionDefinition}
+ */
 export default function (defData) {
+  /** @type {import('./defs').ProjectionDefinition} */
   var self = {};
   var paramObj = defData.split('+').map(function (v) {
     return v.trim();
   }).filter(function (a) {
     return a;
   }).reduce(function (p, a) {
+    /** @type {Array<?>} */
     var split = a.split('=');
     split.push(true);
     p[split[0].toLowerCase()] = split[1];

--- a/lib/projections/aea.js
+++ b/lib/projections/aea.js
@@ -4,6 +4,30 @@ import adjust_lon from '../common/adjust_lon';
 import asinz from '../common/asinz';
 import { EPSLN } from '../constants/values';
 
+/**
+ * @typedef {Object} LocalThis
+ * @property {number} temp
+ * @property {number} es
+ * @property {number} e3
+ * @property {number} sin_po
+ * @property {number} cos_po
+ * @property {number} t1
+ * @property {number} con
+ * @property {number} ms1
+ * @property {number} qs1
+ * @property {number} t2
+ * @property {number} ms2
+ * @property {number} qs2
+ * @property {number} t3
+ * @property {number} qs0
+ * @property {number} ns0
+ * @property {number} c
+ * @property {number} rh
+ * @property {number} sin_phi
+ * @property {number} cos_phi
+ */
+
+/** @this {import('../defs.js').ProjectionDefinition & LocalThis} */
 export function init() {
   if (Math.abs(this.lat1 + this.lat2) < EPSLN) {
     return;
@@ -41,6 +65,7 @@ export function init() {
 
 /* Albers Conical Equal Area forward equations--mapping lat,long to x,y
   ------------------------------------------------------------------- */
+/** @this {import('../defs.js').ProjectionDefinition & LocalThis} */
 export function forward(p) {
   var lon = p.x;
   var lat = p.y;

--- a/lib/projections/aeqd.js
+++ b/lib/projections/aeqd.js
@@ -9,6 +9,15 @@ import asinz from '../common/asinz';
 import imlfn from '../common/imlfn';
 import { Geodesic } from 'geographiclib-geodesic';
 
+/**
+ * @typedef {Object} LocalThis
+ * @property {number} es
+ * @property {number} sin_p12
+ * @property {number} cos_p12
+ * @property {import('geographiclib-geodesic').GeodesicClass} g
+ */
+
+/** @this {import('../defs.js').ProjectionDefinition & LocalThis} */
 export function init() {
   this.sin_p12 = Math.sin(this.lat0);
   this.cos_p12 = Math.cos(this.lat0);

--- a/lib/projections/bonne.js
+++ b/lib/projections/bonne.js
@@ -6,8 +6,19 @@ import pj_inv_mlfn from '../common/pj_inv_mlfn';
 import pj_mlfn from '../common/pj_mlfn';
 import { HALF_PI } from '../constants/values';
 
+/**
+ * @typedef {Object} LocalThis
+ * @property {number} phi1
+ * @property {number} cphi1
+ * @property {number} es
+ * @property {Array<number>} en
+ * @property {number} m1
+ * @property {number} am1
+ */
+
 var EPS10 = 1e-10;
 
+/** @this {import('../defs.js').ProjectionDefinition & LocalThis} */
 export function init() {
   var c;
 

--- a/lib/projections/cass.js
+++ b/lib/projections/cass.js
@@ -9,6 +9,17 @@ import adjust_lat from '../common/adjust_lat';
 import imlfn from '../common/imlfn';
 import { HALF_PI, EPSLN } from '../constants/values';
 
+/**
+ * @typedef {Object} LocalThis
+ * @property {number} es
+ * @property {number} e0
+ * @property {number} e1
+ * @property {number} e2
+ * @property {number} e3
+ * @property {number} ml0
+ */
+
+/** @this {import('../defs.js').ProjectionDefinition & LocalThis} */
 export function init() {
   if (!this.sphere) {
     this.e0 = e0fn(this.es);

--- a/lib/projections/cea.js
+++ b/lib/projections/cea.js
@@ -3,11 +3,17 @@ import qsfnz from '../common/qsfnz';
 import msfnz from '../common/msfnz';
 import iqsfnz from '../common/iqsfnz';
 
-/*
+/**
+ * @typedef {Object} LocalThis
+ * @property {number} e
+ */
+
+/**
   reference:
     "Cartographic Projection Procedures for the UNIX Environment-
     A User's Manual" by Gerald I. Evenden,
     USGS Open File Report 90-284and Release 4 Interim Reports (2003)
+  @this {import('../defs.js').ProjectionDefinition & LocalThis}
 */
 export function init() {
   // no-op

--- a/lib/projections/eqdc.js
+++ b/lib/projections/eqdc.js
@@ -9,6 +9,28 @@ import adjust_lat from '../common/adjust_lat';
 import imlfn from '../common/imlfn';
 import { EPSLN } from '../constants/values';
 
+/**
+ * @typedef {Object} LocalThis
+ * @property {number} temp
+ * @property {number} es
+ * @property {number} e
+ * @property {number} e0
+ * @property {number} e1
+ * @property {number} e2
+ * @property {number} e3
+ * @property {number} sin_phi
+ * @property {number} cos_phi
+ * @property {number} ms1
+ * @property {number} ml1
+ * @property {number} ms2
+ * @property {number} ml2
+ * @property {number} ns
+ * @property {number} g
+ * @property {number} ml0
+ * @property {number} rh
+ */
+
+/** @this {import('../defs.js').ProjectionDefinition & LocalThis} */
 export function init() {
   /* Place parameters in static storage for common use
       ------------------------------------------------- */
@@ -25,18 +47,18 @@ export function init() {
   this.e2 = e2fn(this.es);
   this.e3 = e3fn(this.es);
 
-  this.sinphi = Math.sin(this.lat1);
-  this.cosphi = Math.cos(this.lat1);
+  this.sin_phi = Math.sin(this.lat1);
+  this.cos_phi = Math.cos(this.lat1);
 
-  this.ms1 = msfnz(this.e, this.sinphi, this.cosphi);
+  this.ms1 = msfnz(this.e, this.sin_phi, this.cos_phi);
   this.ml1 = mlfn(this.e0, this.e1, this.e2, this.e3, this.lat1);
 
   if (Math.abs(this.lat1 - this.lat2) < EPSLN) {
-    this.ns = this.sinphi;
+    this.ns = this.sin_phi;
   } else {
-    this.sinphi = Math.sin(this.lat2);
-    this.cosphi = Math.cos(this.lat2);
-    this.ms2 = msfnz(this.e, this.sinphi, this.cosphi);
+    this.sin_phi = Math.sin(this.lat2);
+    this.cos_phi = Math.cos(this.lat2);
+    this.ms2 = msfnz(this.e, this.sin_phi, this.cos_phi);
     this.ml2 = mlfn(this.e0, this.e1, this.e2, this.e3, this.lat2);
     this.ns = (this.ms1 - this.ms2) / (this.ml2 - this.ml1);
   }

--- a/lib/projections/equi.js
+++ b/lib/projections/equi.js
@@ -1,5 +1,12 @@
 import adjust_lon from '../common/adjust_lon';
 
+/**
+ * @typedef {Object} LocalThis
+ * @property {number} t1
+ * @property {number} t2
+ */
+
+/** @this {import('../defs.js').ProjectionDefinition} */
 export function init() {
   this.x0 = this.x0 || 0;
   this.y0 = this.y0 || 0;
@@ -8,8 +15,10 @@ export function init() {
   /// this.t2;
 }
 
-/* Equirectangular forward equations--mapping lat,long to x,y
-  --------------------------------------------------------- */
+/**
+ * Equirectangular forward equations--mapping lat,long to x,y
+ * @this {import('../defs.js').ProjectionDefinition & LocalThis}
+ */
 export function forward(p) {
   var lon = p.x;
   var lat = p.y;

--- a/lib/projections/etmerc.js
+++ b/lib/projections/etmerc.js
@@ -10,6 +10,18 @@ import clens from '../common/clens';
 import clens_cmplx from '../common/clens_cmplx';
 import adjust_lon from '../common/adjust_lon';
 
+/**
+ * @typedef {Object} LocalThis
+ * @property {number} es
+ * @property {Array<number>} cbg
+ * @property {Array<number>} cgb
+ * @property {Array<number>} utg
+ * @property {Array<number>} gtu
+ * @property {number} Qn
+ * @property {number} Zb
+ */
+
+/** @this {import('../defs.js').ProjectionDefinition & LocalThis} */
 export function init() {
   if (!this.approx && (isNaN(this.es) || this.es <= 0)) {
     throw new Error('Incorrect elliptical usage. Try using the +approx option in the proj string, or PROJECTION["Fast_Transverse_Mercator"] in the WKT.');

--- a/lib/projections/gauss.js
+++ b/lib/projections/gauss.js
@@ -2,6 +2,18 @@ import srat from '../common/srat';
 var MAX_ITER = 20;
 import { HALF_PI, FORTPI } from '../constants/values';
 
+/**
+ * @typedef {Object} LocalThis
+ * @property {number} rc
+ * @property {number} C
+ * @property {number} phic0
+ * @property {number} ratexp
+ * @property {number} K
+ * @property {number} e
+ * @property {number} es
+ */
+
+/** @this {import('../defs.js').ProjectionDefinition & LocalThis} */
 export function init() {
   var sphi = Math.sin(this.lat0);
   var cphi = Math.cos(this.lat0);

--- a/lib/projections/geos.js
+++ b/lib/projections/geos.js
@@ -1,5 +1,21 @@
 import hypot from '../common/hypot';
 
+/**
+ * @typedef {Object} LocalThis
+ * @property {1 | 0} flip_axis
+ * @property {number} h
+ * @property {number} radius_g_1
+ * @property {number} radius_g
+ * @property {number} radius_p
+ * @property {number} radius_p2
+ * @property {number} radius_p_inv2
+ * @property {'ellipse'|'sphere'} shape
+ * @property {number} C
+ * @property {string} sweep
+ * @property {number} es
+ */
+
+/** @this {import('../defs.js').ProjectionDefinition & LocalThis} */
 export function init() {
   this.flip_axis = (this.sweep === 'x' ? 1 : 0);
   this.h = Number(this.h);

--- a/lib/projections/gnom.js
+++ b/lib/projections/gnom.js
@@ -2,12 +2,21 @@ import adjust_lon from '../common/adjust_lon';
 import asinz from '../common/asinz';
 import { EPSLN } from '../constants/values';
 
-/*
+/**
+ * @typedef {Object} LocalThis
+ * @property {number} sin_p14
+ * @property {number} cos_p14
+ * @property {number} infinity_dist
+ * @property {number} rc
+ */
+
+/**
   reference:
     Wolfram Mathworld "Gnomonic Projection"
     http://mathworld.wolfram.com/GnomonicProjection.html
     Accessed: 12th November 2009
-  */
+   @this {import('../defs.js').ProjectionDefinition & LocalThis}
+ */
 export function init() {
   /* Place parameters in static storage for common use
       ------------------------------------------------- */

--- a/lib/projections/gstmerc.js
+++ b/lib/projections/gstmerc.js
@@ -3,6 +3,18 @@ import sinh from '../common/sinh';
 import cosh from '../common/cosh';
 import invlatiso from '../common/invlatiso';
 
+/**
+ * @typedef {Object} LocalThis
+ * @property {number} e
+ * @property {number} lc
+ * @property {number} rs
+ * @property {number} cp
+ * @property {number} n2
+ * @property {number} xs
+ * @property {number} ys
+*/
+
+/** @this {import('../defs.js').ProjectionDefinition & LocalThis} */
 export function init() {
   // array of:  a, b, lon0, lat0, k0, x0, y0
   var temp = this.b / this.a;

--- a/lib/projections/laea.js
+++ b/lib/projections/laea.js
@@ -3,6 +3,24 @@ import { HALF_PI, EPSLN, FORTPI } from '../constants/values';
 import qsfnz from '../common/qsfnz';
 import adjust_lon from '../common/adjust_lon';
 
+/**
+ * @typedef {Object} LocalThis
+ * @property {number} mode
+ * @property {Array<number>} apa
+ * @property {number} dd
+ * @property {number} e
+ * @property {number} es
+ * @property {number} mmf
+ * @property {number} rq
+ * @property {number} qp
+ * @property {number} sinb1
+ * @property {number} cosb1
+ * @property {number} ymf
+ * @property {number} xmf
+ * @property {number} sinph0
+ * @property {number} cosph0
+ */
+
 /*
   reference
     "New Equal-Area Map Projections for Noncircular Regions", John P. Snyder,
@@ -10,21 +28,22 @@ import adjust_lon from '../common/adjust_lon';
   */
 
 export var S_POLE = 1;
-
 export var N_POLE = 2;
 export var EQUIT = 3;
 export var OBLIQ = 4;
 
-/* Initialize the Lambert Azimuthal Equal Area projection
-  ------------------------------------------------------ */
+/**
+ * Initialize the Lambert Azimuthal Equal Area projection
+ * @this {import('../defs.js').ProjectionDefinition & LocalThis}
+ */
 export function init() {
   var t = Math.abs(this.lat0);
   if (Math.abs(t - HALF_PI) < EPSLN) {
-    this.mode = this.lat0 < 0 ? this.S_POLE : this.N_POLE;
+    this.mode = this.lat0 < 0 ? S_POLE : N_POLE;
   } else if (Math.abs(t) < EPSLN) {
-    this.mode = this.EQUIT;
+    this.mode = EQUIT;
   } else {
-    this.mode = this.OBLIQ;
+    this.mode = OBLIQ;
   }
   if (this.es > 0) {
     var sinphi;
@@ -33,19 +52,19 @@ export function init() {
     this.mmf = 0.5 / (1 - this.es);
     this.apa = authset(this.es);
     switch (this.mode) {
-      case this.N_POLE:
+      case N_POLE:
         this.dd = 1;
         break;
-      case this.S_POLE:
+      case S_POLE:
         this.dd = 1;
         break;
-      case this.EQUIT:
+      case EQUIT:
         this.rq = Math.sqrt(0.5 * this.qp);
         this.dd = 1 / this.rq;
         this.xmf = 1;
         this.ymf = 0.5 * this.qp;
         break;
-      case this.OBLIQ:
+      case OBLIQ:
         this.rq = Math.sqrt(0.5 * this.qp);
         sinphi = Math.sin(this.lat0);
         this.sinb1 = qsfnz(this.e, sinphi) / this.qp;
@@ -56,7 +75,7 @@ export function init() {
         break;
     }
   } else {
-    if (this.mode === this.OBLIQ) {
+    if (this.mode === OBLIQ) {
       this.sinph0 = Math.sin(this.lat0);
       this.cosph0 = Math.cos(this.lat0);
     }

--- a/lib/projections/lcc.js
+++ b/lib/projections/lcc.js
@@ -4,6 +4,16 @@ import sign from '../common/sign';
 import adjust_lon from '../common/adjust_lon';
 import phi2z from '../common/phi2z';
 import { HALF_PI, EPSLN } from '../constants/values';
+
+/**
+ * @typedef {Object} LocalThis
+ * @property {number} e
+ * @property {number} ns
+ * @property {number} f0
+ * @property {number} rh
+ */
+
+/** @this {import('../defs.js').ProjectionDefinition & LocalThis} */
 export function init() {
   // double lat0;                    /* the reference latitude               */
   // double long0;                   /* the reference longitude              */

--- a/lib/projections/merc.js
+++ b/lib/projections/merc.js
@@ -4,6 +4,15 @@ import adjust_lon from '../common/adjust_lon';
 import tsfnz from '../common/tsfnz';
 import phi2z from '../common/phi2z';
 import { FORTPI, R2D, EPSLN, HALF_PI } from '../constants/values';
+
+/**
+ * @typedef {Object} LocalThis
+ * @property {number} es
+ * @property {number} e
+ * @property {number} k
+ */
+
+/** @this {import('../defs.js').ProjectionDefinition & LocalThis} */
 export function init() {
   var con = this.b / this.a;
   this.es = 1 - con * con;

--- a/lib/projections/omerc.js
+++ b/lib/projections/omerc.js
@@ -4,6 +4,29 @@ import phi2z from '../common/phi2z';
 import { EPSLN, HALF_PI, TWO_PI, FORTPI } from '../constants/values';
 import { getNormalizedProjName } from '../projections';
 
+/**
+ * @typedef {Object} LocalThis
+ * @property {boolean} no_off
+ * @property {boolean} no_rot
+ * @property {number} rectified_grid_angle
+ * @property {number} es
+ * @property {number} A
+ * @property {number} B
+ * @property {number} E
+ * @property {number} e
+ * @property {number} lam0
+ * @property {number} singam
+ * @property {number} cosgam
+ * @property {number} sinrot
+ * @property {number} cosrot
+ * @property {number} rB
+ * @property {number} ArB
+ * @property {number} BrA
+ * @property {number} u_0
+ * @property {number} v_pole_n
+ * @property {number} v_pole_s
+ */
+
 var TOL = 1e-7;
 
 function isTypeA(P) {
@@ -13,8 +36,10 @@ function isTypeA(P) {
   return 'no_uoff' in P || 'no_off' in P || typeAProjections.indexOf(projectionName) !== -1 || typeAProjections.indexOf(getNormalizedProjName(projectionName)) !== -1;
 }
 
-/* Initialize the Oblique Mercator  projection
-    ------------------------------------------ */
+/**
+ * Initialize the Oblique Mercator  projection
+ * @this {import('../defs.js').ProjectionDefinition & LocalThis}
+ */
 export function init() {
   var con, com, cosph0, D, F, H, L, sinph0, p, J, gamma = 0,
     gamma0, lamc = 0, lam1 = 0, lam2 = 0, phi1 = 0, phi2 = 0, alpha_c = 0;
@@ -107,9 +132,9 @@ export function init() {
     J = (J - L * H) / (J + L * H);
     con = lam1 - lam2;
 
-    if (con < -Math.pi) {
+    if (con < -Math.PI) {
       lam2 -= TWO_PI;
-    } else if (con > Math.pi) {
+    } else if (con > Math.PI) {
       lam2 += TWO_PI;
     }
 

--- a/lib/projections/ortho.js
+++ b/lib/projections/ortho.js
@@ -2,6 +2,13 @@ import adjust_lon from '../common/adjust_lon';
 import asinz from '../common/asinz';
 import { EPSLN, HALF_PI } from '../constants/values';
 
+/**
+ * @typedef {Object} LocalThis
+ * @property {number} sin_p14
+ * @property {number} cos_p14
+ */
+
+/** @this {import('../defs.js').ProjectionDefinition & LocalThis} */
 export function init() {
   // double temp;      /* temporary variable    */
 

--- a/lib/projections/poly.js
+++ b/lib/projections/poly.js
@@ -8,8 +8,22 @@ import mlfn from '../common/mlfn';
 import { EPSLN } from '../constants/values';
 
 import gN from '../common/gN';
+
+/**
+ * @typedef {Object} LocalThis
+ * @property {number} temp
+ * @property {number} es
+ * @property {number} e
+ * @property {number} e0
+ * @property {number} e1
+ * @property {number} e2
+ * @property {number} e3
+ * @property {number} ml0
+ */
+
 var MAX_ITER = 20;
 
+/** @this {import('../defs.js').ProjectionDefinition & LocalThis} */
 export function init() {
   /* Place parameters in static storage for common use
       ------------------------------------------------- */

--- a/lib/projections/qsc.js
+++ b/lib/projections/qsc.js
@@ -3,6 +3,16 @@
 
 import { EPSLN, TWO_PI, SPI, HALF_PI, FORTPI } from '../constants/values';
 
+/**
+ * @typedef {Object} LocalThis
+ * @property {number} face
+ * @property {number} x0
+ * @property {number} y0
+ * @property {number} es
+ * @property {number} one_minus_f
+ * @property {number} one_minus_f_squared
+ */
+
 /* constants */
 var FACE_ENUM = {
   FRONT: 1,
@@ -20,6 +30,7 @@ var AREA_ENUM = {
   AREA_3: 4
 };
 
+/** @this {import('../defs.js').ProjectionDefinition & LocalThis} */
 export function init() {
   this.x0 = this.x0 || 0;
   this.y0 = this.y0 || 0;

--- a/lib/projections/sinu.js
+++ b/lib/projections/sinu.js
@@ -8,6 +8,17 @@ import { EPSLN, HALF_PI } from '../constants/values';
 
 import asinz from '../common/asinz';
 
+/**
+ * @typedef {Object} LocalThis
+ * @property {Array<number>} en
+ * @property {number} n
+ * @property {number} m
+ * @property {number} C_y
+ * @property {number} C_x
+ * @property {number} es
+ */
+
+/** @this {import('../defs.js').ProjectionDefinition & LocalThis} */
 export function init() {
   /* Place parameters in static storage for common use
     ------------------------------------------------- */

--- a/lib/projections/somerc.js
+++ b/lib/projections/somerc.js
@@ -6,6 +6,16 @@
     http://www.swisstopo.admin.ch/internet/swisstopo/fr/home/topics/survey/sys/refsys/switzerland.parsysrelated1.31216.downloadList.77004.DownloadFile.tmp/swissprojectionfr.pdf
   */
 
+/**
+ * @typedef {Object} LocalThis
+ * @property {number} lambda0
+ * @property {number} e
+ * @property {number} R
+ * @property {number} b0
+ * @property {number} K
+ */
+
+/** @this {import('../defs.js').ProjectionDefinition & LocalThis} */
 export function init() {
   var phy0 = this.lat0;
   this.lambda0 = this.long0;

--- a/lib/projections/stere.js
+++ b/lib/projections/stere.js
@@ -6,11 +6,25 @@ import tsfnz from '../common/tsfnz';
 import phi2z from '../common/phi2z';
 import adjust_lon from '../common/adjust_lon';
 
+/**
+ * @typedef {Object} LocalThis
+ * @property {number} coslat0
+ * @property {number} sinlat0
+ * @property {number} ms1
+ * @property {number} X0
+ * @property {number} cosX0
+ * @property {number} sinX0
+ * @property {number} con
+ * @property {number} cons
+ * @property {number} e
+ */
+
 export function ssfn_(phit, sinphi, eccen) {
   sinphi *= eccen;
   return (Math.tan(0.5 * (HALF_PI + phit)) * Math.pow((1 - sinphi) / (1 + sinphi), 0.5 * eccen));
 }
 
+/** @this {import('../defs.js').ProjectionDefinition & LocalThis} */
 export function init() {
   // setting default parameters
   this.x0 = this.x0 || 0;
@@ -43,7 +57,7 @@ export function init() {
       this.k0 = 0.5 * this.cons * msfnz(this.e, Math.sin(this.lat_ts), Math.cos(this.lat_ts)) / tsfnz(this.e, this.con * this.lat_ts, this.con * Math.sin(this.lat_ts));
     }
     this.ms1 = msfnz(this.e, this.sinlat0, this.coslat0);
-    this.X0 = 2 * Math.atan(this.ssfn_(this.lat0, this.sinlat0, this.e)) - HALF_PI;
+    this.X0 = 2 * Math.atan(ssfn_(this.lat0, this.sinlat0, this.e)) - HALF_PI;
     this.cosX0 = Math.cos(this.X0);
     this.sinX0 = Math.sin(this.X0);
   }
@@ -72,7 +86,7 @@ export function forward(p) {
     p.y = this.a * A * (this.coslat0 * sinlat - this.sinlat0 * coslat * Math.cos(dlon)) + this.y0;
     return p;
   } else {
-    X = 2 * Math.atan(this.ssfn_(lat, sinlat, this.e)) - HALF_PI;
+    X = 2 * Math.atan(ssfn_(lat, sinlat, this.e)) - HALF_PI;
     cosX = Math.cos(X);
     sinX = Math.sin(X);
     if (Math.abs(this.coslat0) <= EPSLN) {

--- a/lib/projections/sterea.js
+++ b/lib/projections/sterea.js
@@ -2,6 +2,16 @@ import gauss from './gauss';
 import adjust_lon from '../common/adjust_lon';
 import hypot from '../common/hypot';
 
+/**
+ * @typedef {Object} LocalThis
+ * @property {number} sinc0
+ * @property {number} cosc0
+ * @property {number} R2
+ * @property {number} rc
+ * @property {number} phic0
+ */
+
+/** @this {import('../defs.js').ProjectionDefinition & LocalThis} */
 export function init() {
   gauss.init.apply(this);
   if (!this.rc) {

--- a/lib/projections/tmerc.js
+++ b/lib/projections/tmerc.js
@@ -9,6 +9,14 @@ import adjust_lon from '../common/adjust_lon';
 import { EPSLN, HALF_PI } from '../constants/values';
 import sign from '../common/sign';
 
+/**
+ * @typedef {Object} LocalThis
+ * @property {number} es
+ * @property {Array<number>} en
+ * @property {number} ml0
+ */
+
+/** @this {import('../defs.js').ProjectionDefinition & LocalThis} */
 export function init() {
   this.x0 = this.x0 !== undefined ? this.x0 : 0;
   this.y0 = this.y0 !== undefined ? this.y0 : 0;

--- a/lib/projections/tpers.js
+++ b/lib/projections/tpers.js
@@ -1,12 +1,32 @@
+import { D2R, HALF_PI, EPSLN } from '../constants/values';
+import hypot from '../common/hypot';
+
+/**
+ * @typedef {Object} LocalThis
+ * @property {number} mode
+ * @property {number} sinph0
+ * @property {number} cosph0
+ * @property {number} pn1
+ * @property {number} h
+ * @property {number} rp
+ * @property {number} p
+ * @property {number} h1
+ * @property {number} pfact
+ * @property {number} es
+ * @property {number} tilt
+ * @property {number} azi
+ * @property {number} cg
+ * @property {number} sg
+ * @property {number} cw
+ * @property {number} sw
+ */
+
 var mode = {
   N_POLE: 0,
   S_POLE: 1,
   EQUIT: 2,
   OBLIQ: 3
 };
-
-import { D2R, HALF_PI, EPSLN } from '../constants/values';
-import hypot from '../common/hypot';
 
 var params = {
   h: { def: 100000, num: true }, // default is Karman line, no default in PROJ.7
@@ -16,6 +36,7 @@ var params = {
   lat0: { def: 0, num: true } // default is Equator, conversion to rad is automatic
 };
 
+/** @this {import('../defs.js').ProjectionDefinition & LocalThis} */
 export function init() {
   Object.keys(params).forEach(function (p) {
     if (typeof this[p] === 'undefined') {

--- a/lib/projections/utm.js
+++ b/lib/projections/utm.js
@@ -3,6 +3,7 @@ import etmerc from './etmerc';
 export var dependsOn = 'etmerc';
 import { D2R } from '../constants/values';
 
+/** @this {import('../defs.js').ProjectionDefinition} */
 export function init() {
   var zone = adjust_zone(this.zone, this.long0);
   if (zone === undefined) {

--- a/lib/projections/vandg.js
+++ b/lib/projections/vandg.js
@@ -4,8 +4,15 @@ import { HALF_PI, EPSLN } from '../constants/values';
 
 import asinz from '../common/asinz';
 
-/* Initialize the Van Der Grinten projection
-  ---------------------------------------- */
+/**
+ * @typedef {Object} LocalThis
+ * @property {number} R - Radius of the Earth
+ */
+
+/**
+ * Initialize the Van Der Grinten projection
+ * @this {import('../defs.js').ProjectionDefinition & LocalThis}
+ */
 export function init() {
   // this.R = 6370997; //Radius of earth
   this.R = this.a;

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -11,6 +11,13 @@ function checkNotWGS(source, dest) {
   || ((dest.datum.datum_type === PJD_3PARAM || dest.datum.datum_type === PJD_7PARAM || dest.datum.datum_type === PJD_GRIDSHIFT) && source.datumCode !== 'WGS84');
 }
 
+/**
+ * @param {import('./defs').ProjectionDefinition} source
+ * @param {import('./defs').ProjectionDefinition} dest
+ * @param {import('./core').TemplateCoordinates} point
+ * @param {boolean} enforceAxis
+ * @returns {import('./core').InterfaceCoordinates | undefined}
+ */
 export default function transform(source, dest, point, enforceAxis) {
   var wgs84;
   if (Array.isArray(point)) {
@@ -66,6 +73,8 @@ export default function transform(source, dest, point, enforceAxis) {
   if (!point) {
     return;
   }
+
+  point = /** @type {import('./core').InterfaceCoordinates} */ (point);
 
   // Adjust for the prime meridian if necessary
   if (dest.from_greenwich) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,8 @@
         "mocha": "^10.2.0",
         "nyc": "^17.1.0",
         "puppeteer": "^24.2.0",
-        "rollup": "^4.9.6"
+        "rollup": "^4.9.6",
+        "typescript": "^5.8.3"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -5771,7 +5772,6 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10064,8 +10064,7 @@
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "unc-path-regex": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -5,19 +5,21 @@
   "homepage": "https://proj4js.github.io/proj4js/",
   "main": "dist/proj4-src.js",
   "module": "lib/index.js",
+  "types": "dist/lib/index.js",
   "scripts": {
     "prepare": "npm run build && npm run test:all",
     "build": "grunt && npm run rollup",
     "build:tmerc": "grunt build:tmerc && npm run rollup",
     "rollup": "rollup -c",
-    "pretest": "npm run lint",
+    "pretest": "npm run lint && npm run types",
     "lint": "eslint *.js *.mjs scripts lib test",
     "format": "npm run lint -- --fix",
     "test": "npm run build && npm run test:all",
     "test:coverage": "nyc npm run test:ci",
     "test:all": "npm run test:ci && npm run test:browser",
     "test:browser": "node test/puppeteer-tests.mjs",
-    "test:ci": "npx -y mocha test/test-ci.mjs --reporter dot"
+    "test:ci": "npx -y mocha test/test-ci.mjs --reporter dot",
+    "types": "tsc"
   },
   "repository": {
     "type": "git",
@@ -40,7 +42,8 @@
     "mocha": "^10.2.0",
     "nyc": "^17.1.0",
     "puppeteer": "^24.2.0",
-    "rollup": "^4.9.6"
+    "rollup": "^4.9.6",
+    "typescript": "^5.8.3"
   },
   "dependencies": {
     "geographiclib-geodesic": "^2.1.1",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "skipLibCheck": true,
+    "emitDeclarationOnly": true,
+    "declaration": true,
+    "declarationDir": "dist",
+  },
+  "include": [
+    "lib/index.d.ts",
+    "lib/**/*.js",
+  ],
+}


### PR DESCRIPTION
This pull request adds JSDoc types to the library and publishes .t.ts files. So it is no longer necessary for TypeScript users to install the `@types/proj4` package.