### PR TITLE
Make geotiff a dev depencency again

### DIFF
--- a/lib/nadgrid.js
+++ b/lib/nadgrid.js
@@ -40,6 +40,22 @@
 
 /** @typedef {{header: NadgridHeader, subgrids: Array<Subgrid>}} NADGrid */
 
+/**
+ * @typedef {Object} GeoTIFF
+ * @property {() => Promise<number>} getImageCount - Returns the number of images in the GeoTIFF.
+ * @property {(index: number) => Promise<GeoTIFFImage>} getImage - Returns a GeoTIFFImage for the given index.
+ */
+
+/**
+ * @typedef {Object} GeoTIFFImage
+ * @property {() => number} getWidth - Returns the width of the image.
+ * @property {() => number} getHeight - Returns the height of the image.
+ * @property {() => number[]} getBoundingBox - Returns the bounding box as [minX, minY, maxX, maxY] in degrees.
+ * @property {() => Promise<ArrayLike<ArrayLike<number>>>} readRasters - Returns the raster data as an array of bands.
+ * @property {Object} fileDirectory - The file directory object containing metadata.
+ * @property {Object} fileDirectory.ModelPixelScale - The pixel scale array [scaleX, scaleY, scaleZ] in degrees.
+ */
+
 var loadedNadgrids = {};
 
 /**
@@ -52,14 +68,14 @@ var loadedNadgrids = {};
 /**
  * @overload
  * @param {string} key - The key to associate with the loaded grid.
- * @param {import('geotiff').GeoTIFF} data - The GeoTIFF instance to read the grid from.
+ * @param {GeoTIFF} data - The GeoTIFF instance to read the grid from.
  * @returns {{ready: Promise<NADGrid>}} - A promise that resolves to the loaded grid information.
  */
 /**
  * Load either a NTv2 file (.gsb) or a Geotiff (.tif) to a key that can be used in a proj string like +nadgrids=<key>. Pass the NTv2 file
  * as an ArrayBuffer. Pass Geotiff as a GeoTIFF instance from the geotiff.js library.
  * @param {string} key - The key to associate with the loaded grid.
- * @param {ArrayBuffer|import('geotiff').GeoTIFF} data The data to load, either an ArrayBuffer for NTv2 or a GeoTIFF instance.
+ * @param {ArrayBuffer|GeoTIFF} data The data to load, either an ArrayBuffer for NTv2 or a GeoTIFF instance.
  * @param {NTV2GridOptions} [options] Optional parameters.
  * @returns {{ready: Promise<NADGrid>}|NADGrid} - A promise that resolves to the loaded grid information.
  */
@@ -92,7 +108,7 @@ function readNTV2Grid(key, data, options) {
 
 /**
  * @param {string} key The key to associate with the loaded grid.
- * @param {import('geotiff').GeoTIFF} tiff The GeoTIFF instance to read the grid from.
+ * @param {GeoTIFF} tiff The GeoTIFF instance to read the grid from.
  * @returns {Promise<NADGrid>} A promise that resolves to the loaded NAD grid information.
  */
 async function readGeotiffGrid(key, tiff) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@stylistic/eslint-plugin": "^4.2.0",
         "chai": "^5.0.0",
         "eslint": "^9.25.1",
+        "geotiff": "^2.1.4-beta.0",
         "grunt": "^1.6.1",
         "grunt-cli": "^1.4.3",
         "mocha": "^10.2.0",
@@ -32,9 +33,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ahocevar"
-      },
-      "peerDependencies": {
-        "geotiff": "*"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -781,8 +779,8 @@
       "version": "3.9.2",
       "resolved": "https://registry.npmjs.org/@petamoriken/float16/-/float16-3.9.2.tgz",
       "integrity": "sha512-VgffxawQde93xKxT3qap3OH+meZf7VaSB5Sqd4Rqc+FP5alWbpOyan/7tRbOAvynjpG3GpdtAuGU/NdhQpmrog==",
-      "license": "MIT",
-      "peer": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@puppeteer/browsers": {
       "version": "2.7.1",
@@ -3115,20 +3113,20 @@
       }
     },
     "node_modules/geotiff": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/geotiff/-/geotiff-2.1.3.tgz",
-      "integrity": "sha512-PT6uoF5a1+kbC3tHmZSUsLHBp2QJlHasxxxxPW47QIY1VBKpFB+FcDvX+MxER6UzgLQZ0xDzJ9s48B9JbOCTqA==",
+      "version": "2.1.4-beta.0",
+      "resolved": "https://registry.npmjs.org/geotiff/-/geotiff-2.1.4-beta.0.tgz",
+      "integrity": "sha512-jb6SYvHMyiCqwqgGGLDAxtig9h1g6O+n1wEyNEE4QgVEXOItYaWrEgPg9SAnwdoZm2yx6DpFtilbGG65hvZgpQ==",
+      "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@petamoriken/float16": "^3.4.7",
         "lerc": "^3.0.0",
         "pako": "^2.0.4",
         "parse-headers": "^2.0.2",
         "quick-lru": "^6.1.1",
-        "web-worker": "^1.2.0",
-        "xml-utils": "^1.0.2",
-        "zstddec": "^0.1.0"
+        "web-worker": "^1.5.0",
+        "xml-utils": "^1.10.2",
+        "zstddec": "^0.2.0-alpha.3"
       },
       "engines": {
         "node": ">=10.19"
@@ -4089,8 +4087,8 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lerc/-/lerc-3.0.0.tgz",
       "integrity": "sha512-Rm4J/WaHhRa93nCN2mwWDZFoRVF18G1f47C+kvQWyHGEZxFpTUi73p7lMVSAndyxGt6lJ2/CFbOcf9ra5p8aww==",
-      "license": "Apache-2.0",
-      "peer": true
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/levn": {
       "version": "0.4.1",
@@ -4961,8 +4959,8 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
       "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
-      "license": "(MIT AND Zlib)",
-      "peer": true
+      "dev": true,
+      "license": "(MIT AND Zlib)"
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
@@ -4994,8 +4992,8 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.6.tgz",
       "integrity": "sha512-Tz11t3uKztEW5FEVZnj1ox8GKblWn+PvHY9TmJV5Mll2uHEwRdR/5Li1OlXoECjLYkApdhWy44ocONwXLiKO5A==",
-      "license": "MIT",
-      "peer": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/parse-json": {
       "version": "5.2.0",
@@ -5329,8 +5327,8 @@
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-6.1.2.tgz",
       "integrity": "sha512-AAFUA5O1d83pIHEhJwWCq/RQcRukCkn/NSm2QsTEMle5f2hP0ChI2+3Xb051PZCkLryI/Ir1MVKviT2FIloaTQ==",
+      "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6112,8 +6110,8 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/web-worker/-/web-worker-1.5.0.tgz",
       "integrity": "sha512-RiMReJrTAiA+mBjGONMnjVDP2u3p9R1vkcGz6gDIrOMT3oGuYwX2WRMYI9ipkphSuE5XKEhydbhNEJh4NY9mlw==",
-      "license": "Apache-2.0",
-      "peer": true
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -6222,8 +6220,8 @@
       "version": "1.10.2",
       "resolved": "https://registry.npmjs.org/xml-utils/-/xml-utils-1.10.2.tgz",
       "integrity": "sha512-RqM+2o1RYs6T8+3DzDSoTRAUfrvaejbVHcp3+thnAtDKo8LskR+HomLajEy5UjTz24rpka7AxVBRR3g2wTUkJA==",
-      "license": "CC0-1.0",
-      "peer": true
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/y18n": {
       "version": "5.0.8",
@@ -6318,11 +6316,11 @@
       }
     },
     "node_modules/zstddec": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/zstddec/-/zstddec-0.1.0.tgz",
-      "integrity": "sha512-w2NTI8+3l3eeltKAdK8QpiLo/flRAr2p8AGeakfMZOXBxOg9HIu4LVDxBi81sYgVhFhdJjv1OrB5ssI8uFPoLg==",
-      "license": "MIT AND BSD-3-Clause",
-      "peer": true
+      "version": "0.2.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/zstddec/-/zstddec-0.2.0-alpha.3.tgz",
+      "integrity": "sha512-uHyE3TN8jRFOaMVwdhERfrcaabyoUUawIRDKXE6x0nCU7mzyIZO0LndJ3AtVUiKLF0lC+8F5bMSySWEF586PSA==",
+      "dev": true,
+      "license": "MIT AND BSD-3-Clause"
     }
   },
   "dependencies": {
@@ -6844,7 +6842,7 @@
       "version": "3.9.2",
       "resolved": "https://registry.npmjs.org/@petamoriken/float16/-/float16-3.9.2.tgz",
       "integrity": "sha512-VgffxawQde93xKxT3qap3OH+meZf7VaSB5Sqd4Rqc+FP5alWbpOyan/7tRbOAvynjpG3GpdtAuGU/NdhQpmrog==",
-      "peer": true
+      "dev": true
     },
     "@puppeteer/browsers": {
       "version": "2.7.1",
@@ -8356,19 +8354,19 @@
       "dev": true
     },
     "geotiff": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/geotiff/-/geotiff-2.1.3.tgz",
-      "integrity": "sha512-PT6uoF5a1+kbC3tHmZSUsLHBp2QJlHasxxxxPW47QIY1VBKpFB+FcDvX+MxER6UzgLQZ0xDzJ9s48B9JbOCTqA==",
-      "peer": true,
+      "version": "2.1.4-beta.0",
+      "resolved": "https://registry.npmjs.org/geotiff/-/geotiff-2.1.4-beta.0.tgz",
+      "integrity": "sha512-jb6SYvHMyiCqwqgGGLDAxtig9h1g6O+n1wEyNEE4QgVEXOItYaWrEgPg9SAnwdoZm2yx6DpFtilbGG65hvZgpQ==",
+      "dev": true,
       "requires": {
         "@petamoriken/float16": "^3.4.7",
         "lerc": "^3.0.0",
         "pako": "^2.0.4",
         "parse-headers": "^2.0.2",
         "quick-lru": "^6.1.1",
-        "web-worker": "^1.2.0",
-        "xml-utils": "^1.0.2",
-        "zstddec": "^0.1.0"
+        "web-worker": "^1.5.0",
+        "xml-utils": "^1.10.2",
+        "zstddec": "^0.2.0-alpha.3"
       }
     },
     "get-caller-file": {
@@ -9069,7 +9067,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lerc/-/lerc-3.0.0.tgz",
       "integrity": "sha512-Rm4J/WaHhRa93nCN2mwWDZFoRVF18G1f47C+kvQWyHGEZxFpTUi73p7lMVSAndyxGt6lJ2/CFbOcf9ra5p8aww==",
-      "peer": true
+      "dev": true
     },
     "levn": {
       "version": "0.4.1",
@@ -9720,7 +9718,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
       "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
-      "peer": true
+      "dev": true
     },
     "parent-module": {
       "version": "1.0.1",
@@ -9746,7 +9744,7 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.6.tgz",
       "integrity": "sha512-Tz11t3uKztEW5FEVZnj1ox8GKblWn+PvHY9TmJV5Mll2uHEwRdR/5Li1OlXoECjLYkApdhWy44ocONwXLiKO5A==",
-      "peer": true
+      "dev": true
     },
     "parse-json": {
       "version": "5.2.0",
@@ -9974,7 +9972,7 @@
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-6.1.2.tgz",
       "integrity": "sha512-AAFUA5O1d83pIHEhJwWCq/RQcRukCkn/NSm2QsTEMle5f2hP0ChI2+3Xb051PZCkLryI/Ir1MVKviT2FIloaTQ==",
-      "peer": true
+      "dev": true
     },
     "randombytes": {
       "version": "2.1.0",
@@ -10513,7 +10511,7 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/web-worker/-/web-worker-1.5.0.tgz",
       "integrity": "sha512-RiMReJrTAiA+mBjGONMnjVDP2u3p9R1vkcGz6gDIrOMT3oGuYwX2WRMYI9ipkphSuE5XKEhydbhNEJh4NY9mlw==",
-      "peer": true
+      "dev": true
     },
     "which": {
       "version": "2.0.2",
@@ -10587,7 +10585,7 @@
       "version": "1.10.2",
       "resolved": "https://registry.npmjs.org/xml-utils/-/xml-utils-1.10.2.tgz",
       "integrity": "sha512-RqM+2o1RYs6T8+3DzDSoTRAUfrvaejbVHcp3+thnAtDKo8LskR+HomLajEy5UjTz24rpka7AxVBRR3g2wTUkJA==",
-      "peer": true
+      "dev": true
     },
     "y18n": {
       "version": "5.0.8",
@@ -10657,10 +10655,10 @@
       "dev": true
     },
     "zstddec": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/zstddec/-/zstddec-0.1.0.tgz",
-      "integrity": "sha512-w2NTI8+3l3eeltKAdK8QpiLo/flRAr2p8AGeakfMZOXBxOg9HIu4LVDxBi81sYgVhFhdJjv1OrB5ssI8uFPoLg==",
-      "peer": true
+      "version": "0.2.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/zstddec/-/zstddec-0.2.0-alpha.3.tgz",
+      "integrity": "sha512-uHyE3TN8jRFOaMVwdhERfrcaabyoUUawIRDKXE6x0nCU7mzyIZO0LndJ3AtVUiKLF0lC+8F5bMSySWEF586PSA==",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@stylistic/eslint-plugin": "^4.2.0",
     "chai": "^5.0.0",
     "eslint": "^9.25.1",
+    "geotiff": "^2.1.4-beta.0",
     "grunt": "^1.6.1",
     "grunt-cli": "^1.4.3",
     "mocha": "^10.2.0",
@@ -49,8 +50,5 @@
   "dependencies": {
     "mgrs": "1.0.0",
     "wkt-parser": "^1.5.1"
-  },
-  "peerDependencies": {
-    "geotiff": "*"
   }
 }


### PR DESCRIPTION
This is achieved by adding minimal types for the geotiff.js api, instead of importing types.

Fixes #516 