### PR TITLE
Fix enforceAxis for z and arbitrary orders

### DIFF
--- a/lib/Proj.js
+++ b/lib/Proj.js
@@ -32,6 +32,8 @@ function Projection(srsCode, callback) {
   this.init = null;
   /** @type {string} */
   this.name;
+  /** @type {string} */
+  this.axis;
   /** @type {Array<string>} */
   this.names = null;
   /** @type {string} */

--- a/lib/adjust_axis.js
+++ b/lib/adjust_axis.js
@@ -1,57 +1,79 @@
-export default function (crs, denorm, point) {
-  var xin = point.x,
-    yin = point.y,
-    zin = point.z || 0.0;
-  var v, t, i;
+var order = ['x', 'y', 'z'];
+
+/**
+ * Convert a point in a given CRS axis order to ENU (east/north/up) order
+ * @param {import('./defs').ProjectionDefinition} crs
+ * @param {import('./core').InterfaceCoordinates} point
+ * @returns {import('./core').InterfaceCoordinates | null}
+ */
+export function adjustAxisToEnu(crs, point) {
   /** @type {import("./core").InterfaceCoordinates} */
-  var out = {};
-  for (i = 0; i < 3; i++) {
-    if (denorm && i === 2 && point.z === undefined) {
+  const out = {};
+  for (let i = 0, ii = crs.axis.length; i < ii; i++) {
+    if (i === 2 && point.z === undefined) {
       continue;
     }
-    if (i === 0) {
-      v = xin;
-      if ('ew'.indexOf(crs.axis[i]) !== -1) {
-        t = 'x';
-      } else {
-        t = 'y';
-      }
-    } else if (i === 1) {
-      v = yin;
-      if ('ns'.indexOf(crs.axis[i]) !== -1) {
-        t = 'y';
-      } else {
-        t = 'x';
-      }
-    } else {
-      v = zin;
-      t = 'z';
+    let v = point[order[i]];
+    switch (crs.axis[i]) {
+      case 'e':
+        out.x = v;
+        break;
+      case 'w':
+        out.x = -v;
+        break;
+      case 'n':
+        out.y = v;
+        break;
+      case 's':
+        out.y = -v;
+        break;
+      case 'u':
+        out.z = v;
+        break;
+      case 'd':
+        out.z = -v;
+        break;
+      default:
+        // console.log("ERROR: unknown axis ("+crs.axis[i]+") - check definition of "+crs.projName);
+        return null;
+    }
+  }
+  return out;
+}
+
+/**
+ * Convert a point in ENU (east/north/up) order to the given CRS axis order.
+ * @param {import('./defs').ProjectionDefinition} crs
+ * @param {import('./core').InterfaceCoordinates} point
+ * @returns {import('./core').InterfaceCoordinates | null}
+ */
+export function adjustAxisFromEnu(crs, point) {
+  const out = /** @type {import("./core").InterfaceCoordinates} */ ({});
+  for (let i = 0, ii = crs.axis.length; i < ii; i++) {
+    if (i === 2 && point.z === undefined) {
+      continue;
     }
     switch (crs.axis[i]) {
       case 'e':
-        out[t] = v;
+        out[order[i]] = point.x;
         break;
       case 'w':
-        out[t] = -v;
+        out[order[i]] = -point.x;
         break;
       case 'n':
-        out[t] = v;
+        out[order[i]] = point.y;
         break;
       case 's':
-        out[t] = -v;
+        out[order[i]] = -point.y;
         break;
       case 'u':
-        if (point[t] !== undefined) {
-          out.z = v;
-        }
+        out[order[i]] = point.z;
         break;
       case 'd':
-        if (point[t] !== undefined) {
-          out.z = -v;
-        }
+        out[order[i]] = -point.z;
         break;
       default:
-      // console.log("ERROR: unknow axis ("+crs.axis[i]+") - check definition of "+crs.projName);
+        // console.log("ERROR: unknown axis ("+crs.axis[i]+") - check definition of "+crs.projName);
         return null;
     }
   }

--- a/lib/core.js
+++ b/lib/core.js
@@ -1,5 +1,6 @@
 import proj from './Proj';
-import transform from './transform';
+import { transformInternal } from './transform';
+import toPoint from './common/toPoint';
 var wgs84 = proj('WGS84');
 
 /**
@@ -82,37 +83,36 @@ var wgs84 = proj('WGS84');
  * @returns {T}
  */
 function transformer(from, to, coords, enforceAxis) {
-  var transformedArray, out, keys;
+  var out, geocent, keys;
   if (Array.isArray(coords)) {
-    transformedArray = transform(from, to, coords, enforceAxis) || { x: NaN, y: NaN };
+    out = transformInternal(from, to, toPoint(coords), enforceAxis) || { x: NaN, y: NaN };
     if (coords.length > 2) {
-      if ((typeof from.name !== 'undefined' && from.name === 'geocent') || (typeof to.name !== 'undefined' && to.name === 'geocent')) {
-        if (typeof transformedArray.z === 'number') {
-          return /** @type {T} */ ([transformedArray.x, transformedArray.y, transformedArray.z].concat(coords.slice(3)));
-        } else {
-          return /** @type {T} */ ([transformedArray.x, transformedArray.y, coords[2]].concat(coords.slice(3)));
+      geocent = (typeof from.name !== 'undefined' && from.name === 'geocent') || (typeof to.name !== 'undefined' && to.name === 'geocent');
+      if (geocent) {
+        if (typeof out.z === 'number') {
+          return /** @type {T} */ ([out.x, out.y, out.z].concat(coords.slice(3)));
         }
-      } else {
-        return /** @type {T} */ ([transformedArray.x, transformedArray.y].concat(coords.slice(2)));
+        return /** @type {T} */ ([out.x, out.y, coords[2]].concat(coords.slice(3)));
       }
-    } else {
-      return /** @type {T} */ ([transformedArray.x, transformedArray.y]);
+      if (enforceAxis && typeof out.z === 'number') {
+        return /** @type {T} */ ([out.x, out.y, out.z].concat(coords.slice(3)));
+      }
+      return /** @type {T} */ ([out.x, out.y].concat(coords.slice(2)));
     }
+    return /** @type {T} */ ([out.x, out.y]);
   } else {
-    out = transform(from, to, coords, enforceAxis);
+    out = transformInternal(from, to, { x: coords.x, y: coords.y, z: coords.z, m: coords.m }, enforceAxis) || { x: NaN, y: NaN };
     keys = Object.keys(coords);
     if (keys.length === 2) {
       return /** @type {T} */ (out);
     }
+    geocent = (typeof from.name !== 'undefined' && from.name === 'geocent') || (typeof to.name !== 'undefined' && to.name === 'geocent');
     keys.forEach(function (key) {
-      if ((typeof from.name !== 'undefined' && from.name === 'geocent') || (typeof to.name !== 'undefined' && to.name === 'geocent')) {
-        if (key === 'x' || key === 'y' || key === 'z') {
-          return;
-        }
-      } else {
-        if (key === 'x' || key === 'y') {
-          return;
-        }
+      if (key === 'x' || key === 'y') {
+        return;
+      }
+      if (key === 'z' && (geocent || enforceAxis)) {
+        return;
       }
       out[key] = coords[key];
     });

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -1,6 +1,6 @@
 import { D2R, R2D, PJD_3PARAM, PJD_7PARAM, PJD_GRIDSHIFT } from './constants/values';
 import datum_transform from './datum_transform';
-import adjust_axis from './adjust_axis';
+import { adjustAxisToEnu, adjustAxisFromEnu } from './adjust_axis';
 import proj from './Proj';
 import toPoint from './common/toPoint';
 import checkSanity from './checkSanity';
@@ -12,36 +12,26 @@ function checkNotWGS(source, dest) {
 }
 
 /**
+ * Internal transform: accepts an already-cloned point object, returns transformed point object.
  * @param {import('./defs').ProjectionDefinition} source
  * @param {import('./defs').ProjectionDefinition} dest
- * @param {import('./core').TemplateCoordinates} point
- * @param {boolean} enforceAxis
+ * @param {import('./core').InterfaceCoordinates} point
+ * @param {boolean} [enforceAxis]
  * @returns {import('./core').InterfaceCoordinates | undefined}
  */
-export default function transform(source, dest, point, enforceAxis) {
+export function transformInternal(source, dest, point, enforceAxis) {
   var wgs84;
-  if (Array.isArray(point)) {
-    point = toPoint(point);
-  } else {
-    // Clone the point object so inputs don't get modified
-    point = {
-      x: point.x,
-      y: point.y,
-      z: point.z,
-      m: point.m
-    };
-  }
   var hasZ = point.z !== undefined;
   checkSanity(point);
   // Workaround for datum shifts towgs84, if either source or destination projection is not wgs84
   if (source.datum && dest.datum && checkNotWGS(source, dest)) {
     wgs84 = new proj('WGS84');
-    point = transform(source, wgs84, point, enforceAxis);
+    point = transformInternal(source, wgs84, point, enforceAxis);
     source = wgs84;
   }
   // DGR, 2010/11/12
   if (enforceAxis && source.axis !== 'enu') {
-    point = adjust_axis(source, false, point);
+    point = adjustAxisToEnu(source, point);
   }
   // Transform source points to long/lat, if they aren't already.
   if (source.projName === 'longlat') {
@@ -105,11 +95,29 @@ export default function transform(source, dest, point, enforceAxis) {
 
   // DGR, 2010/11/12
   if (enforceAxis && dest.axis !== 'enu') {
-    return adjust_axis(dest, true, point);
+    return adjustAxisFromEnu(dest, point);
   }
 
   if (point && !hasZ && dest.projName !== 'geocent') {
     delete point.z;
   }
   return point;
+}
+
+/**
+ * @param {import('./defs').ProjectionDefinition} source
+ * @param {import('./defs').ProjectionDefinition} dest
+ * @param {import('./core').TemplateCoordinates} point
+ * @param {boolean} [enforceAxis]
+ * @returns {import('./core').InterfaceCoordinates | undefined}
+ */
+export default function transform(source, dest, point, enforceAxis) {
+  var pt;
+  if (Array.isArray(point)) {
+    pt = toPoint(point);
+  } else {
+    // Clone the point object so inputs don't get modified
+    pt = { x: point.x, y: point.y, z: point.z, m: point.m };
+  }
+  return transformInternal(source, dest, pt, enforceAxis);
 }

--- a/test/proj4.test.mjs
+++ b/test/proj4.test.mjs
@@ -319,6 +319,35 @@ describe('proj4', function () {
     assert.closeTo(rslt.y, 10.2, 0.000001);
   });
 
+  it('should respect the vertical axis when enforceAxis is true', function () {
+    var enu = '+proj=longlat +ellps=WGS84 +datum=WGS84 +units=degrees +axis=enu';
+    var ned = '+proj=longlat +ellps=WGS84 +datum=WGS84 +units=degrees +axis=ned';
+    var arrayResult = proj4(enu, ned).forward([10, 20, 30], true);
+    assert.equal(arrayResult[0], 20, 'array: first (north) is input y');
+    assert.equal(arrayResult[1], 10, 'array: second (east) is input x');
+    assert.equal(arrayResult[2], -30, 'array: third (down) negates input z');
+    var pointResult = proj4(enu, ned).forward({ x: 10, y: 20, z: 30 }, true);
+    assert.equal(pointResult.x, 20, 'point: x (north) is input y');
+    assert.equal(pointResult.y, 10, 'point: y (east) is input x');
+    assert.equal(pointResult.z, -30, 'point: z (down) negates input z');
+  });
+
+  it('should handle non-trivial axis reordering with enforceAxis', function () {
+    var neu = '+proj=longlat +axis=neu';
+    var uen = '+proj=longlat +axis=uen';
+    // neu source [north=10, east=20, up=30] → uen dest [up, east, north]
+    var r1 = proj4(neu, uen).forward([10, 20, 30], true);
+    assert.equal(r1[0], 30, 'neu→uen: first (up) is input up');
+    assert.equal(r1[1], 20, 'neu→uen: second (east) is input east');
+    assert.equal(r1[2], 10, 'neu→uen: third (north) is input north');
+    // uen source [up=10, east=20, north=30] → uen dest: round-trip should be identity
+    var r2 = proj4(uen, uen).forward([10, 20, 30], true);
+    assert.equal(r2[0], 10, 'uen→uen: round-trip preserves first');
+    assert.equal(r2[1], 20, 'uen→uen: round-trip preserves second');
+    // r2[2] is the north component (y in ENU space), which goes through D2R/R2D in longlat
+    assert.closeTo(r2[2], 30, 1e-6, 'uen→uen: round-trip preserves third');
+  });
+
   it('axes should be invertable with proj4.transform()', function () {
     var enu = '+proj=longlat +axis=enu';
     var esu = '+proj=longlat +axis=esu';


### PR DESCRIPTION
Fixes #575.

This pull request also simplifies the `adjust_axis()` function and avoids repeated checks for point object/array in `transform()`.