### PR TITLE
Add +lon_wrap support

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 ## Change log
 
-- 2.20.9: Add Eckert VI (eck6) projection; add geotiff@3 support (geotiff is now an optional peer dependency); fix unknown datum handling to match PROJ behavior; fix gamma without alpha in omerc; fix ob_tran lam offset and +over handling; fix enforceAxis for z and arbitrary axis orders
+- 2.20.9: Add Eckert VI (eck6) projection; add geotiff@3 support (geotiff is now an optional peer dependency); add support for `+lon_wrap`; fix unknown datum handling to match PROJ behavior; fix gamma without alpha in omerc; fix ob_tran lam offset and +over handling; fix enforceAxis for z and arbitrary axis orders
 
 - 2.20.8: Add back TypeScript type definitions to the npm package (accidentally removed in 2.20.7)
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
 ## Change log
 
-- 2.20.9: Add Eckert VI (eck6) projection; add geotiff@3 support (geotiff is now an optional peer dependency); add support for `+lon_wrap`; fix unknown datum handling to match PROJ behavior; fix gamma without alpha in omerc; fix ob_tran lam offset and +over handling; fix enforceAxis for z and arbitrary axis orders
+- 2.21.0: Add support for `+lon_wrap`
+- 2.20.9: Add Eckert VI (eck6) projection; add geotiff@3 support (geotiff is now an optional peer dependency); fix unknown datum handling to match PROJ behavior; fix gamma without alpha in omerc; fix ob_tran lam offset and +over handling; fix enforceAxis for z and arbitrary axis orders
 
 - 2.20.8: Add back TypeScript type definitions to the npm package (accidentally removed in 2.20.7)
 

--- a/lib/defs.js
+++ b/lib/defs.js
@@ -17,6 +17,7 @@ import wkt from 'wkt-parser';
  * @property {number} [long0]
  * @property {number} [long1]
  * @property {number} [long2]
+ * @property {number} [long_wrap]
  * @property {number} [alpha]
  * @property {number} [longc]
  * @property {number} [x0]

--- a/lib/projString.js
+++ b/lib/projString.js
@@ -43,6 +43,9 @@ export default function (defData) {
     lon_0: function (v) {
       self.long0 = v * D2R;
     },
+    lon_wrap: function (v) {
+      self.long_wrap = parseFloat(v) * D2R;
+    },
     lon_1: function (v) {
       self.long1 = v * D2R;
     },

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -1,5 +1,6 @@
-import { D2R, R2D, TWO_PI, PJD_3PARAM, PJD_7PARAM, PJD_GRIDSHIFT } from './constants/values';
+import { D2R, R2D, PJD_3PARAM, PJD_7PARAM, PJD_GRIDSHIFT } from './constants/values';
 import datum_transform from './datum_transform';
+import adjust_lon from './common/adjust_lon';
 import { adjustAxisToEnu, adjustAxisFromEnu } from './adjust_axis';
 import proj from './Proj';
 import toPoint from './common/toPoint';
@@ -78,12 +79,7 @@ export function transformInternal(source, dest, point, enforceAxis) {
   if (dest.projName === 'longlat') {
     // wrap longitude into the range centered on dest.long_wrap, if requested (+lon_wrap)
     if (dest.long_wrap !== undefined) {
-      while (point.x < dest.long_wrap - Math.PI) {
-        point.x += TWO_PI;
-      }
-      while (point.x > dest.long_wrap + Math.PI) {
-        point.x -= TWO_PI;
-      }
+      point.x = dest.long_wrap + adjust_lon(point.x - dest.long_wrap);
     }
     // convert radians to decimal degrees
     point = {

--- a/lib/transform.js
+++ b/lib/transform.js
@@ -1,4 +1,4 @@
-import { D2R, R2D, PJD_3PARAM, PJD_7PARAM, PJD_GRIDSHIFT } from './constants/values';
+import { D2R, R2D, TWO_PI, PJD_3PARAM, PJD_7PARAM, PJD_GRIDSHIFT } from './constants/values';
 import datum_transform from './datum_transform';
 import { adjustAxisToEnu, adjustAxisFromEnu } from './adjust_axis';
 import proj from './Proj';
@@ -76,6 +76,15 @@ export function transformInternal(source, dest, point, enforceAxis) {
   }
 
   if (dest.projName === 'longlat') {
+    // wrap longitude into the range centered on dest.long_wrap, if requested (+lon_wrap)
+    if (dest.long_wrap !== undefined) {
+      while (point.x < dest.long_wrap - Math.PI) {
+        point.x += TWO_PI;
+      }
+      while (point.x > dest.long_wrap + Math.PI) {
+        point.x -= TWO_PI;
+      }
+    }
     // convert radians to decimal degrees
     point = {
       x: point.x * R2D,

--- a/test/proj4.test.mjs
+++ b/test/proj4.test.mjs
@@ -42,6 +42,15 @@ describe('proj2proj', function () {
     assert.closeTo(rslt[0], 1271137.927561178, 0.000001);
     assert.closeTo(rslt[1], 6404230.291456626, 0.000001);
   });
+  it('should wrap longitude into the 0..360 range with +lon_wrap', function () {
+    var wgs84 = '+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs';
+    var wrapped = '+proj=longlat +ellps=WGS84 +datum=WGS84 +lon_wrap=180 +no_defs';
+    assert.closeTo(proj4(wgs84, wrapped).forward([-170, 40])[0], 190, 0.000001);
+    assert.closeTo(proj4(wgs84, wrapped).forward([-180, 0])[0], 180, 0.000001);
+    assert.closeTo(proj4(wgs84, wrapped).forward([10, 0])[0], 10, 0.000001);
+    // without +lon_wrap the longitude stays in the -180..180 range
+    assert.closeTo(proj4(wgs84, wgs84).forward([-170, 40])[0], -170, 0.000001);
+  });
 });
 
 describe('proj4', function () {


### PR DESCRIPTION
Fixes #180

Adds parsing of the `+lon_wrap` parameter and wraps longitude output into the range centered on that value, matching PROJ (results land in `[lon_wrap - 180, lon_wrap + 180]`). So `+lon_wrap=180` puts output in 0..360 and -170 comes out as 190, while leaving the default -180..180 behavior untouched when it isn't set. Added a test covering the wrapped and unwrapped cases.