### PR TITLE
Default lon_0 to 0 in aeqd, merc and lcc

### DIFF
--- a/lib/projections/aeqd.js
+++ b/lib/projections/aeqd.js
@@ -24,6 +24,7 @@ export function init() {
   this.cos_p12 = Math.cos(this.lat0);
   this.x0 = this.x0 || 0;
   this.y0 = this.y0 || 0;
+  this.long0 = this.long0 || 0;
   // flattening for ellipsoid
   this.f = this.es / (1 + Math.sqrt(1 - this.es));
 }

--- a/lib/projections/lcc.js
+++ b/lib/projections/lcc.js
@@ -35,6 +35,7 @@ export function init() {
   }
   this.x0 = this.x0 || 0;
   this.y0 = this.y0 || 0;
+  this.long0 = this.long0 || 0;
   // Standard Parallels cannot be equal and on opposite sides of the equator
   if (Math.abs(this.lat1 + this.lat2) < EPSLN) {
     return;

--- a/lib/projections/merc.js
+++ b/lib/projections/merc.js
@@ -22,6 +22,7 @@ export function init() {
   if (!('y0' in this)) {
     this.y0 = 0;
   }
+  this.long0 = this.long0 || 0;
   this.e = Math.sqrt(this.es);
   if (this.lat_ts) {
     if (this.sphere) {

--- a/test/testData.js
+++ b/test/testData.js
@@ -1346,6 +1346,19 @@ var testPoints = [
     ll: [2, 48],
     xy: [249325.62485355, -187277.841415147]
   }, {
+    // lon_0 omitted: defaults to 0, same result as +lon_0=0
+    code: '+proj=aeqd +lat_0=51.5 +datum=WGS84 +units=m +no_defs',
+    ll: [2, 48],
+    xy: [149325.62485313, -387277.84141508]
+  }, {
+    code: '+proj=merc +a=6378137 +b=6378137 +units=m +no_defs',
+    ll: [10, 45],
+    xy: [1113194.90793274, 5621521.48619207]
+  }, {
+    code: '+proj=lcc +lat_1=33 +lat_2=45 +lat_0=39 +datum=WGS84 +units=m +no_defs',
+    ll: [-100, 40],
+    xy: [-6880442.71344780, 4330863.47097279]
+  }, {
     code: '+proj=laea +lat_0=2 +lon_0=1 +x_0=0 +y_0=0 +a=6371000 +b=6371000  +units=m +no_defs',
     ll: [1, 2],
     xy: [0, 0]


### PR DESCRIPTION
#560 added `this.long0 = this.long0 || 0` to sinu, and #578 added the `x0`/`y0` defaults to aeqd. These three projections default `x0`/`y0` in `init()` but never default `long0`, so they return `NaN` when a definition omits `+lon_0`. PROJ treats a missing `lon_0` as `0`, and the other projections that already guard it (sinu, eqc, equi, ortho, qsc, robin, stere) use the same `|| 0` idiom.

`forward`/`inverse` read `this.long0` directly:

- aeqd: `adjust_lon(lon - this.long0, this.over)`
- merc: `adjust_lon(lon - this.long0, this.over)`
- lcc: `this.ns * adjust_lon(lon - this.long0, this.over)`

With `long0` undefined that subtraction is `NaN`.

Before:

```js
proj4('+proj=merc +a=6378137 +b=6378137 +units=m +no_defs', [10, 45])
// [NaN, 5621521.486192066]
proj4('+proj=lcc +lat_1=33 +lat_2=45 +lat_0=39 +datum=WGS84 +units=m +no_defs', [-100, 40])
// [NaN, NaN]
proj4('+proj=aeqd +lat_0=51.5 +datum=WGS84 +units=m +no_defs', [2, 48])
// [NaN, NaN]
```

After (identical to adding `+lon_0=0`):

```js
// merc -> [1113194.90793274, 5621521.48619207]
// lcc  -> [-6880442.71344780, 4330863.47097279]
// aeqd -> [149325.62485313, -387277.84141508]
```

Added one test point per projection in `testData.js` with `+lon_0` omitted. They fail with `NaN` before the change and round-trip through the inverse after it.
