### PR TITLE
fix(nzmg): add iterations to default export

### DIFF
--- a/lib/projections/nzmg.js
+++ b/lib/projections/nzmg.js
@@ -222,5 +222,6 @@ export default {
   init: init,
   forward: forward,
   inverse: inverse,
-  names: names
+  names: names,
+  iterations: iterations
 };

--- a/test/proj4.test.mjs
+++ b/test/proj4.test.mjs
@@ -873,4 +873,15 @@ describe('proj4', function () {
       }, 'Invalid value for o_lat_1: o_lat_1 should be different from zero', 'should work');
     });
   });
+
+  describe('nzmg projection', function () {
+    var proj = proj4('+proj=nzmg +lat_0=-41 +lon_0=173 +x_0=2510000 +y_0=6023150 +ellps=intl +no_defs');
+    var nzmg = [2152713.585, 5442524.565];
+    it('should round trip through inverse and forward', function () {
+      var lonlat = proj.inverse(nzmg);
+      var backToNzmg = proj.forward(lonlat);
+      assert.closeTo(backToNzmg[0], nzmg[0], 1e-2, 'easting is close');
+      assert.closeTo(backToNzmg[1], nzmg[1], 1e-2, 'northing is close');
+    });
+  });
 });


### PR DESCRIPTION
Fixes #581  & adds a test case

`iterations` was missing from the default export for when `nzmg.js` so `extend(this, ourProj)` in `Proj.js` never copies it onto the instance and the inverse fixed-point loop runs 0 times. This caused a ~17 m drift on `forward(inverse(x))` round-trips for EPSG:27200.