### PR TITLE
Fix plessis ellipsoid: 6355863 is the semi-minor axis, not the inverse flattening

### DIFF
--- a/lib/constants/Ellipsoid.js
+++ b/lib/constants/Ellipsoid.js
@@ -177,7 +177,7 @@ var ellipsoids = {
   },
   plessis: {
     a: 6376523,
-    rf: 6355863,
+    b: 6355863,
     ellipseName: 'Plessis 1817 (France)'
   },
   krass: {

--- a/test/proj4.test.mjs
+++ b/test/proj4.test.mjs
@@ -27,6 +27,19 @@ describe('parse', function () {
   });
 });
 
+describe('ellipsoid', function () {
+  it('plessis uses 6355863 as the semi-minor axis, not the inverse flattening', function () {
+    // 6355863 is Plessis 1817's semi-minor axis b (rf is ~308.64), not an inverse
+    // flattening; reading it as rf produces a near-sphere. Expected values from PROJ 9.5.1
+    // (with the near-sphere bug the northing was 6444643.06 instead of 6413002.84).
+    var wgs84 = '+proj=longlat +datum=WGS84 +no_defs';
+    var plessis = '+proj=merc +ellps=plessis +lon_0=0 +x_0=0 +y_0=0 +units=m +no_defs';
+    var rslt = proj4(wgs84, plessis).forward([10, 50]);
+    assert.closeTo(rslt[0], 1112913.211791, 0.001);
+    assert.closeTo(rslt[1], 6413002.836941, 0.001);
+  });
+});
+
 describe('proj2proj', function () {
   it('should work transforming from one projection to another', function () {
     var sweref99tm = '+proj=utm +zone=33 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs';

--- a/test/proj4.test.mjs
+++ b/test/proj4.test.mjs
@@ -27,19 +27,6 @@ describe('parse', function () {
   });
 });
 
-describe('ellipsoid', function () {
-  it('plessis uses 6355863 as the semi-minor axis, not the inverse flattening', function () {
-    // 6355863 is Plessis 1817's semi-minor axis b (rf is ~308.64), not an inverse
-    // flattening; reading it as rf produces a near-sphere. Expected values from PROJ 9.5.1
-    // (with the near-sphere bug the northing was 6444643.06 instead of 6413002.84).
-    var wgs84 = '+proj=longlat +datum=WGS84 +no_defs';
-    var plessis = '+proj=merc +ellps=plessis +lon_0=0 +x_0=0 +y_0=0 +units=m +no_defs';
-    var rslt = proj4(wgs84, plessis).forward([10, 50]);
-    assert.closeTo(rslt[0], 1112913.211791, 0.001);
-    assert.closeTo(rslt[1], 6413002.836941, 0.001);
-  });
-});
-
 describe('proj2proj', function () {
   it('should work transforming from one projection to another', function () {
     var sweref99tm = '+proj=utm +zone=33 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs';

--- a/test/testData.js
+++ b/test/testData.js
@@ -2604,7 +2604,6 @@ var testPoints = [
     ll: [90, -70],
     xy: [343065.9150369169, 2254539.6570760156]
   },
-  // plessis: 6355863 is the semi-minor axis, not the inverse flattening (values from PROJ 9.5.1)
   {
     code: '+proj=merc +ellps=plessis +lon_0=0 +x_0=0 +y_0=0 +units=m +no_defs',
     ll: [10, 50],

--- a/test/testData.js
+++ b/test/testData.js
@@ -2603,6 +2603,12 @@ var testPoints = [
     code: '+proj=lcc +lat_0=-90.0 +lon_0=81.0 +lat_1=-72.66666666666674 +lat_2=-75.3333333333334 +x_0=0.0 +y_0=0.0 +ellps=GRS80 +no_defs',
     ll: [90, -70],
     xy: [343065.9150369169, 2254539.6570760156]
+  },
+  // plessis: 6355863 is the semi-minor axis, not the inverse flattening (values from PROJ 9.5.1)
+  {
+    code: '+proj=merc +ellps=plessis +lon_0=0 +x_0=0 +y_0=0 +units=m +no_defs',
+    ll: [10, 50],
+    xy: [1112913.211791464, 6413002.836941121]
   }
 ];
 export default testPoints;


### PR DESCRIPTION
The `plessis` ellipsoid entry stores `6355863` in the `rf` (inverse flattening) slot, but `6355863` is Plessis 1817's semi-minor axis **b** — the inverse flattening is ~308.64. `deriveConstants` reads it as an inverse flattening and derives a near-sphere (`b = (1 - 1/6355863) * a ≈ 6376521.997`), so any transform using `+ellps=plessis` is off.

Mercator of `(10, 50)` before the fix (near-sphere):

```js
proj4('+proj=longlat +datum=WGS84 +no_defs',
      '+proj=merc +ellps=plessis +lon_0=0 +x_0=0 +y_0=0 +units=m +no_defs').forward([10, 50]);
// [1112913.21, 6444643.06]
```

PROJ 9.5.1 / pyproj gives `[1112913.21, 6413002.84]` — a ~31.6 km difference in northing:

```python
from pyproj import Transformer
Transformer.from_crs("EPSG:4326", "+proj=merc +ellps=plessis +units=m",
                     always_xy=True).transform(10, 50)
# (1112913.21, 6413002.84)   # a=6376523, b=6355863, rf≈308.64
```

The fix changes `rf: 6355863` → `b: 6355863`, consistent with the other `b:`-defined ellipsoids already in the table. Added a regression test against PROJ's values; the full suite passes (4318 tests).
