### PR TITLE
Fix Krovak default scale factor when +k is omitted

### DIFF
--- a/lib/projections/krovak.js
+++ b/lib/projections/krovak.js
@@ -10,8 +10,9 @@ export function init() {
   if (!this.long0) {
     this.long0 = 0.7417649320975901 - 0.308341501185665; // 42.5° from Ferro = 24.833° from Greenwich
   }
-  /* if scale not set default to 0.9999 */
-  if (!this.k0) {
+  /* if scale not set default to 0.9999; Proj.js has already defaulted k0 to 1
+     by the time init runs, so treat 1 as unset (k0=1 is not a Krovak definition) */
+  if (!this.k0 || this.k0 === 1) {
     this.k0 = 0.9999;
   }
   this.s45 = 0.785398163397448; /* 45 */

--- a/test/testData.js
+++ b/test/testData.js
@@ -1793,6 +1793,12 @@ var testPoints = [
     ll: [12.806988, 49.452262],
     xy: [-868208.61, -1095793.64]
   },
+  // krovak without +k: scale factor must default to 0.9999 (values from PROJ 9.5.1)
+  {
+    code: '+proj=krovak +lat_0=49.5 +lon_0=24.83333333333333 +alpha=30.28813972222222 +ellps=bessel +pm=greenwich +units=m +no_defs',
+    ll: [14.42, 50.08],
+    xy: [-743101.013894535, -1043898.660355862]
+  },
   {
     code: 'PROJCRS["S-JTSK [JTSK03] / Krovak East North",BASEGEOGCRS["S-JTSK [JTSK03]",DATUM["System of the Unified Trigonometrical Cadastral Network [JTSK03]",ELLIPSOID["Bessel 1841",6377397.155,299.1528128,LENGTHUNIT["metre",1,ID["EPSG",9001]],ID["EPSG",7004]],ID["EPSG",1201]],ID["EPSG",8351]],CONVERSION["Krovak East North (Greenwich)",METHOD["Krovak (North Orientated)",ID["EPSG",1041]],PARAMETER["Latitude of projection centre",49.5000000000003,ANGLEUNIT["degree",0.0174532925199433,ID["EPSG",9102]],ID["EPSG",8811]],PARAMETER["Longitude of origin",24.8333333333336,ANGLEUNIT["degree",0.0174532925199433,ID["EPSG",9102]],ID["EPSG",8833]],PARAMETER["Co-latitude of cone axis",30.2881397527781,ANGLEUNIT["degree",0.0174532925199433,ID["EPSG",9102]],ID["EPSG",1036]],PARAMETER["Latitude of pseudo standard parallel",78.5000000000003,ANGLEUNIT["degree",0.0174532925199433,ID["EPSG",9102]],ID["EPSG",8818]],PARAMETER["Scale factor on pseudo standard parallel",0.9999,SCALEUNIT["unity",1,ID["EPSG",9201]],ID["EPSG",8819]],PARAMETER["False easting",0,LENGTHUNIT["metre",1,ID["EPSG",9001]],ID["EPSG",8806]],PARAMETER["False northing",0,LENGTHUNIT["metre",1,ID["EPSG",9001]],ID["EPSG",8807]],ID["EPSG",5510]],CS[Cartesian,2,ID["EPSG",4499]],AXIS["Easting (X)",east],AXIS["Northing (Y)",north],LENGTHUNIT["metre",1,ID["EPSG",9001]],ID["EPSG",8353]]',
     ll: [12.806988, 49.452262],


### PR DESCRIPTION
Fixes #586.

`Proj.js` sets `json.k0 = json.k0 || 1.0` before a projection's `init` runs, so krovak's `if (!this.k0) this.k0 = 0.9999` never fires and a Krovak definition without `+k` gets projected with a scale factor of 1.0:

```js
proj4('+proj=longlat +ellps=bessel',
      '+proj=krovak +lat_0=49.5 +lon_0=24.83333333333333 +alpha=30.28813972222222 +ellps=bessel +pm=greenwich +units=m +no_defs',
      [14.42, 50.08]);
// before: [-743175.33, -1044003.06]   (~128 m off)
// after:  [-743101.01, -1043898.66]   (matches PROJ 9.5.1 / pyproj, same as an explicit +k=0.9999)
```

This change makes krovak's init treat `k0 === 1` as unset, since by the time it runs the global default has already been applied and `k0 = 1` isn't a real Krovak definition. Added a no-`+k` case to `testData.js` next to the existing explicit-`+k=0.9999` one (values from PROJ 9.5.1); full suite passes.

Not sure this is the best approach, to be honest — the trade-off is that an *explicit* `+k=1` now also becomes 0.9999, whereas PROJ would honor it (a degenerate definition, but still a divergence). The alternative would be to make the `Proj.js` default projection-aware so krovak defaults to 0.9999 there, which keeps explicit values intact but leaks projection-specific knowledge into `Proj.js`. Happy to rework it either way.
