### PR TITLE
Set k0 default after projections had a chance to do so

### DIFF
--- a/lib/Proj.js
+++ b/lib/Proj.js
@@ -61,7 +61,6 @@ function Projection(srsCode, callback) {
       json.datumName = datumDef.datumName ? datumDef.datumName : json.datumCode;
     }
   }
-  json.k0 = json.k0 || 1.0;
   json.axis = json.axis || 'enu';
   json.ellps = json.ellps || 'wgs84';
   json.lat1 = json.lat1 || json.lat0; // Lambert_Conformal_Conic_1SP, for example, needs this
@@ -93,6 +92,11 @@ function Projection(srsCode, callback) {
   // init the projection
   if ('init' in this && typeof this.init === 'function') {
     this.init();
+  }
+
+  // only default the scale factor once the projection had a chance to set its own
+  if (!this.k0) {
+    this.k0 = 1.0;
   }
 
   // legecy callback from back in the day when it went to spatialreference.org

--- a/lib/projections/etmerc.js
+++ b/lib/projections/etmerc.js
@@ -37,6 +37,7 @@ export function init() {
   this.y0 = this.y0 !== undefined ? this.y0 : 0;
   this.long0 = this.long0 !== undefined ? this.long0 : 0;
   this.lat0 = this.lat0 !== undefined ? this.lat0 : 0;
+  this.k0 = this.k0 !== undefined ? this.k0 : 1;
 
   this.cgb = [];
   this.cbg = [];

--- a/lib/projections/gstmerc.js
+++ b/lib/projections/gstmerc.js
@@ -17,6 +17,9 @@ import invlatiso from '../common/invlatiso';
 /** @this {import('../defs.js').ProjectionDefinition & LocalThis} */
 export function init() {
   // array of:  a, b, lon0, lat0, k0, x0, y0
+  if (!this.k0) {
+    this.k0 = 1;
+  }
   var temp = this.b / this.a;
   this.e = Math.sqrt(1 - temp * temp);
   this.lc = this.long0;

--- a/lib/projections/omerc.js
+++ b/lib/projections/omerc.js
@@ -44,6 +44,10 @@ export function init() {
   var con, com, cosph0, D, F, H, L, sinph0, p, J, gamma = 0,
     gamma0, lamc = 0, lam1 = 0, lam2 = 0, phi1 = 0, phi2 = 0, alpha_c = 0;
 
+  if (!this.k0) {
+    this.k0 = 1;
+  }
+
   // only Type A uses the no_off or no_uoff property
   // https://github.com/OSGeo/proj.4/issues/104
   this.no_off = isTypeA(this);

--- a/lib/projections/somerc.js
+++ b/lib/projections/somerc.js
@@ -17,6 +17,9 @@
 
 /** @this {import('../defs.js').ProjectionDefinition & LocalThis} */
 export function init() {
+  if (!this.k0) {
+    this.k0 = 1;
+  }
   var phy0 = this.lat0;
   this.lambda0 = this.long0;
   var sinPhy0 = Math.sin(phy0);

--- a/lib/projections/stere.js
+++ b/lib/projections/stere.js
@@ -35,7 +35,7 @@ export function init() {
   this.coslat0 = Math.cos(this.lat0);
   this.sinlat0 = Math.sin(this.lat0);
   if (this.sphere) {
-    if (this.k0 === 1 && !isNaN(this.lat_ts) && Math.abs(this.coslat0) <= EPSLN) {
+    if (!isNaN(this.lat_ts) && Math.abs(this.coslat0) <= EPSLN) {
       this.k0 = 0.5 * (1 + sign(this.lat0) * Math.sin(this.lat_ts));
     }
   } else {
@@ -51,9 +51,9 @@ export function init() {
       }
     }
     this.cons = Math.sqrt(Math.pow(1 + this.e, 1 + this.e) * Math.pow(1 - this.e, 1 - this.e));
-    if (this.k0 === 1 && !isNaN(this.lat_ts) && Math.abs(this.coslat0) <= EPSLN && Math.abs(Math.cos(this.lat_ts)) > EPSLN) {
-      // When k0 is 1 (default value) and lat_ts is a vaild number and lat0 is at a pole and lat_ts is not at a pole
-      // Recalculate k0 using formula 21-35 from p161 of Snyder, 1987
+    if (!isNaN(this.lat_ts) && Math.abs(this.coslat0) <= EPSLN && Math.abs(Math.cos(this.lat_ts)) > EPSLN) {
+      // Polar Stereographic variant B: k0 is derived from lat_ts (EPSG guidance note 7-2, method 9829)
+      // https://epsg.org/coord-operation-method_9829/Polar-Stereographic-variant-B.html
       this.k0 = 0.5 * this.cons * msfnz(this.e, Math.sin(this.lat_ts), Math.cos(this.lat_ts)) / tsfnz(this.e, this.con * this.lat_ts, this.con * Math.sin(this.lat_ts));
     }
     this.ms1 = msfnz(this.e, this.sinlat0, this.coslat0);

--- a/test/testData.js
+++ b/test/testData.js
@@ -1799,6 +1799,11 @@ var testPoints = [
     xy: [-868208.61, -1095793.64]
   },
   {
+    code: '+proj=krovak +lat_0=49.5 +lon_0=24.83333333333333 +alpha=30.28813972222222 +ellps=bessel +pm=greenwich +units=m +no_defs',
+    ll: [14.42, 50.08],
+    xy: [-743101.013894535, -1043898.660355862]
+  },
+  {
     code: 'PROJCRS["S-JTSK [JTSK03] / Krovak East North",BASEGEOGCRS["S-JTSK [JTSK03]",DATUM["System of the Unified Trigonometrical Cadastral Network [JTSK03]",ELLIPSOID["Bessel 1841",6377397.155,299.1528128,LENGTHUNIT["metre",1,ID["EPSG",9001]],ID["EPSG",7004]],ID["EPSG",1201]],ID["EPSG",8351]],CONVERSION["Krovak East North (Greenwich)",METHOD["Krovak (North Orientated)",ID["EPSG",1041]],PARAMETER["Latitude of projection centre",49.5000000000003,ANGLEUNIT["degree",0.0174532925199433,ID["EPSG",9102]],ID["EPSG",8811]],PARAMETER["Longitude of origin",24.8333333333336,ANGLEUNIT["degree",0.0174532925199433,ID["EPSG",9102]],ID["EPSG",8833]],PARAMETER["Co-latitude of cone axis",30.2881397527781,ANGLEUNIT["degree",0.0174532925199433,ID["EPSG",9102]],ID["EPSG",1036]],PARAMETER["Latitude of pseudo standard parallel",78.5000000000003,ANGLEUNIT["degree",0.0174532925199433,ID["EPSG",9102]],ID["EPSG",8818]],PARAMETER["Scale factor on pseudo standard parallel",0.9999,SCALEUNIT["unity",1,ID["EPSG",9201]],ID["EPSG",8819]],PARAMETER["False easting",0,LENGTHUNIT["metre",1,ID["EPSG",9001]],ID["EPSG",8806]],PARAMETER["False northing",0,LENGTHUNIT["metre",1,ID["EPSG",9001]],ID["EPSG",8807]],ID["EPSG",5510]],CS[Cartesian,2,ID["EPSG",4499]],AXIS["Easting (X)",east],AXIS["Northing (Y)",north],LENGTHUNIT["metre",1,ID["EPSG",9001]],ID["EPSG",8353]]',
     ll: [12.806988, 49.452262],
     xy: [-868207.48, -1095791.49]


### PR DESCRIPTION
Alternative to and closes #590.

Instead of assuming a k0 of 1 to mean "not set", this pull request changes the init sequence so a default is only set if a projection did not do so.