### PR TITLE
Fix ortho x0

### DIFF
--- a/lib/projections/ortho.js
+++ b/lib/projections/ortho.js
@@ -39,7 +39,7 @@ export function forward(p) {
   g = this.sin_p14 * sinphi + this.cos_p14 * cosphi * coslon;
   ksp = 1;
   if ((g > 0) || (Math.abs(g) <= EPSLN)) {
-    x = this.a * ksp * cosphi * Math.sin(dlon);
+    x = (this.x0 || 0) + this.a * ksp * cosphi * Math.sin(dlon);
     y = (this.y0 || 0) + this.a * ksp * (this.cos_p14 * sinphi - this.sin_p14 * cosphi * coslon);
   }
   p.x = x;

--- a/test/proj4.test.mjs
+++ b/test/proj4.test.mjs
@@ -883,6 +883,22 @@ describe('proj4', function () {
     });
   });
 
+  describe('ortho projection', function () {
+    var proj = proj4('+proj=ortho +lat_0=10 +lon_0=20 +x_0=500000 +y_0=200000 +ellps=WGS84 +units=m +no_defs');
+    it('should project the centre onto (x_0, y_0)', function () {
+      var xy = proj.forward([20, 10]);
+      assert.closeTo(xy[0], 500000, 1e-6, 'x is close to x_0');
+      assert.closeTo(xy[1], 200000, 1e-6, 'y is close to y_0');
+    });
+    it('should round trip through forward and inverse', function () {
+      var ll = [24, 13];
+      var xy = proj.forward(ll);
+      var backToLl = proj.inverse(xy);
+      assert.closeTo(backToLl[0], ll[0], 1e-9, 'longitude is close');
+      assert.closeTo(backToLl[1], ll[1], 1e-9, 'latitude is close');
+    });
+  });
+
   describe('nzmg projection', function () {
     var proj = proj4('+proj=nzmg +lat_0=-41 +lon_0=173 +x_0=2510000 +y_0=6023150 +ellps=intl +no_defs');
     var nzmg = [2152713.585, 5442524.565];

--- a/test/proj4.test.mjs
+++ b/test/proj4.test.mjs
@@ -883,22 +883,6 @@ describe('proj4', function () {
     });
   });
 
-  describe('ortho projection', function () {
-    var proj = proj4('+proj=ortho +lat_0=10 +lon_0=20 +x_0=500000 +y_0=200000 +ellps=WGS84 +units=m +no_defs');
-    it('should project the centre onto (x_0, y_0)', function () {
-      var xy = proj.forward([20, 10]);
-      assert.closeTo(xy[0], 500000, 1e-6, 'x is close to x_0');
-      assert.closeTo(xy[1], 200000, 1e-6, 'y is close to y_0');
-    });
-    it('should round trip through forward and inverse', function () {
-      var ll = [24, 13];
-      var xy = proj.forward(ll);
-      var backToLl = proj.inverse(xy);
-      assert.closeTo(backToLl[0], ll[0], 1e-9, 'longitude is close');
-      assert.closeTo(backToLl[1], ll[1], 1e-9, 'latitude is close');
-    });
-  });
-
   describe('nzmg projection', function () {
     var proj = proj4('+proj=nzmg +lat_0=-41 +lon_0=173 +x_0=2510000 +y_0=6023150 +ellps=intl +no_defs');
     var nzmg = [2152713.585, 5442524.565];

--- a/test/testData.js
+++ b/test/testData.js
@@ -738,6 +738,11 @@ var testPoints = [
     }
   },
   {
+    code: '+proj=ortho +lat_0=10 +lon_0=20 +x_0=500000 +y_0=200000 +R=6378137 +units=m +no_defs',
+    ll: [24, 13],
+    xy: [933513.16904843, 536434.69158115]
+  },
+  {
     code: '+proj=ob_tran +o_proj=moll +o_lat_p=45 +o_lon_p=-90',
     ll: [-2, -1],
     xy: [-7421459.08469763, -5444548.62238893]


### PR DESCRIPTION
Apply the false easting `this.x0` on x in ortho projections.

This makes it consistent with y0, and the inverse already subtracts both. Now round-trips correctly.