### PR TITLE
Support latlong, latlon and lonlat as aliases of longlat

### DIFF
--- a/lib/projString.js
+++ b/lib/projString.js
@@ -23,7 +23,10 @@ export default function (defData) {
   }, {});
   var paramName, paramVal, paramOutname;
   var params = {
-    proj: 'projName',
+    proj: function (v) {
+      // 'lonlat', 'latlon' and 'latlong' are aliases of 'longlat'
+      self.projName = ['lonlat', 'latlon', 'latlong'].includes(v) ? 'longlat' : v;
+    },
     datum: 'datumCode',
     rf: function (v) {
       self.rf = parseFloat(v);

--- a/lib/projections/longlat.js
+++ b/lib/projections/longlat.js
@@ -7,7 +7,7 @@ function identity(pt) {
 }
 export { identity as forward };
 export { identity as inverse };
-export var names = ['longlat', 'identity'];
+export var names = ['longlat', 'identity', 'lonlat', 'latlon', 'latlong'];
 export default {
   init: init,
   forward: identity,

--- a/test/proj4.test.mjs
+++ b/test/proj4.test.mjs
@@ -42,6 +42,20 @@ describe('proj2proj', function () {
     assert.closeTo(rslt[0], 1271137.927561178, 0.000001);
     assert.closeTo(rslt[1], 6404230.291456626, 0.000001);
   });
+  it('should support the latlong, latlon and lonlat aliases of longlat', function () {
+    // see https://github.com/proj4js/proj4js/issues/167
+    var grid = '+units=m +a=6371229 +b=6371229 +lon_0=265.0 +proj=lcc +lat_2=25.0 +lat_1=25.0 +lat_0=25.0';
+    ['latlong', 'latlon', 'lonlat'].forEach(function (alias) {
+      var latlong = '+proj=' + alias + ' +a=6371229 +b=6371229';
+      var xy = proj4(latlong, grid).forward([226.541, 12.19]);
+      // reference values computed with PROJ 9.5.1
+      assert.closeTo(xy[0], -4226106.996915471, 0.01, alias + ' x is close');
+      assert.closeTo(xy[1], -832698.2610175635, 0.01, alias + ' y is close');
+      var ll = proj4(latlong, grid).inverse(xy);
+      assert.closeTo(ll[0], -133.459, 0.000001, alias + ' lng is close');
+      assert.closeTo(ll[1], 12.19, 0.000001, alias + ' lat is close');
+    });
+  });
   it('should wrap longitude into the 0..360 range with +lon_wrap', function () {
     var wgs84 = '+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs';
     var wrapped = '+proj=longlat +ellps=WGS84 +datum=WGS84 +lon_wrap=180 +no_defs';

--- a/test/testData.js
+++ b/test/testData.js
@@ -759,6 +759,12 @@ var testPoints = [
 
   },
   {
+    code: '+proj=ob_tran +o_proj=latlon +o_lon_p=0 +o_lat_p=35',
+    ll: [-105, 40],
+    xy: [-60.8425058899586, 32.0797099050498]
+
+  },
+  {
     code: '+proj=ob_tran +o_proj=longlat +o_lon_p=0 +o_lat_p=35 +lon_0=-113 +R=6371229 +no_defs +type=crs',
     ll: [-105, 40],
     xy: [6.32623159167842, -14.6380639304457]


### PR DESCRIPTION
Fixes #167.

PROJ accepts `latlong`, `latlon` and `lonlat` as aliases of `longlat` (same identity operation, axis order unchanged), but proj4js only registered `longlat`, so the `+proj=latlong +a=6371229 +b=6371229` string from the issue was rejected as unsupported. Proj strings now normalize these aliases to `longlat`, and they are also registered as names of the longlat projection so they resolve as `+o_proj` values for `ob_tran`.

The new test converts between `+proj=latlong` and the lcc grid from the issue for all three aliases, with expected values computed with PROJ 9.5.1, and testData gets an `ob_tran +o_proj=latlon` case. `npm test` passes.